### PR TITLE
update simp-metadata format

### DIFF
--- a/v1/channels/development.yaml
+++ b/v1/channels/development.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   development:
-    simp-core:
-      branch: master
-      ref: 172d87e2bc91b0a65c79b7cf06566aa932094362
-    simp-doc:
-      ref: 16559599bfa52e07a7cefdca627937968696ec9b
-      branch: master
-    simp-rsync:
-      ref: ''
-      branch: master
-    pupmod-simp-rsync:
-      ref: 4ba57d001769f8fa54a5e8ff0b5a46253d32bf5f
-      branch: master
-    simp-adapter:
-      ref: eeb6f99fcc84fc512e67079513f3e8711498bc9e
-      branch: master
-    simp-environment:
-      ref: 4a2109c8abc8239ab59f53c4b687485f42ecc0cb
-      branch: master
-    simp-gpgkeys:
-      ref: 6caad667f9a97469f94ec61c11c236509ebe31ed
-      branch: master
-    simp-utils:
-      ref: cd4e69989f0c4cbb83f89eef0367746ab4d36f93
-      branch: master
-    rubygem-simp-cli:
-      ref: dd4ffb348316b05f8d80541a50aa0bc024b8d1a6
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: ''
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: b4bb7f0b89cf4bec2aaffb062f98585086d597fa
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: c10040e9aa83ad5ef425ccedf6ddd94c5a02c2d6
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-    puppetlabs-postgresql:
-      ref: 33baf800f5f433bb51cc0ceb731252c523cf8da5
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-      ref: 1195681a893b3e930e5c06e24bb20200e201d7c5
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-    pupmod-simp-acpid:
-      ref: 58559b46fe16b90623636d887dd65fb498170b6e
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 514fc795997230ba640388a7100c80cb272c7365
-      branch: master
-    pupmod-simp-at:
-      ref: f48bc1fca0588c52e560b5ad73fdf1d1ea6115f1
-      branch: master
-    pupmod-simp-auditd:
-      ref: 833c5887894f4e2aa1d57fc37b81ec3858702eff
-      branch: master
-    pupmod-simp-autofs:
-      ref: 2376e60ff504916e811721991690affc286716b5
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: a70bf2555d8207897f06eb1b89acf49a9dd7add0
-      branch: master
-    pupmod-simp-clamav:
-      ref: 5344b68379d674ea3c533121e76f935661e7149a
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: '06364812bdc24aaf3ae375fddf00bd47a8496699'
-      branch: master
-    pupmod-simp-cron:
-      ref: 33d4f6a3a126366ca0b711c427b12207ff32be43
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 3a3534c6b6be58113a6e1e1804beeaf38de4f4e0
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: 1a75a63a6083d105036bc2d9e4e96ad0f9572bcc
-      branch: master
-    pupmod-simp-fips:
-      ref: 2bea5f763999878f1bc921e9b87289a970fa8ca9
-      branch: master
-    pupmod-simp-freeradius:
-      ref: d540912967a99cba26396854f28946a3776a2859
-      branch: master
-    pupmod-simp-gdm:
-      ref: de354560aa1124823d417230cd8c8e232660f1c6
-      branch: master
-    pupmod-simp-gnome:
-      ref: c2b75953acdd447b9d486bd9afa66b12aead0f8f
-      branch: master
-    puppet-haveged:
-      ref: ''
-      branch: master
-    pupmod-simp-incron:
-      ref: c643a1d2f66f47c35f085f79aa94d607aafc6cd2
-      branch: master
-    pupmod-simp-iptables:
-      ref: '04993ce809070f5f8713ce77ac27101589f99c52'
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: a3e14f8784b5b0b17a63ece8f29908c5065d6762
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: de1a440fb8c45d0415899e726e736158a0413924
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 55290228c4d44dd1731ed10a51bac9b301c911c5
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 0b913a1d1101e05938ada0b67c210b63c8d9a111
-      branch: master
-    pupmod-simp-logrotate:
-      ref: 881dde741e1aa67da6148591e1b40e2248e622ba
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 651c2aa296500c7a44000deecb98216fcf4225f6
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 286cb2db8da152d1077c0936cb2d3d0d7c3bbdbd
-      branch: master
-    pupmod-simp-named:
-      ref: ca6809011f1e688d6e9b0d5c3ddefd6e3d82ef44
-      branch: master
-    pupmod-simp-network:
-      ref: d8ebd3f00515caf0b6ceb7fcc85fcb0ad6b256fb
-      branch: master
-    pupmod-simp-nfs:
-      ref: 690545d7fa83d78f1def0036c3ec2082161dd74f
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 744e7682ea2eaa56329db590a8e2293bfe77baf0
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 1e9befcb907515da0a8f43d86ad7fae1920b571b
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 0baf5b2cf336460913207a87a995518faf011185
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9a3cc5ca8c5b2d81bc248f1ee491c1391c250e61
-      branch: master
-    pupmod-simp-pam:
-      ref: 7a96a927fe898393dca6252b9da91ca130c2db20
-      branch: master
-    pupmod-simp-pki:
-      ref: c081d8cc0d1565e887f65cb41976aa5644bd0880
-      branch: master
-    pupmod-simp-polkit:
-      ref: d23e92ed320ffb41720caa7d864eaa001f38ac9c
-      branch: master
-    pupmod-simp-postfix:
-      ref: ac92dc6f6f410c3119017324adead931f973f71c
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 6f2c1494ead133cb1e20fd9d825f61aa425e74fe
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 15ea0f489d82e80850a28ef4a3a6bc4eb7ce684e
-      branch: master
-    pupmod-simp-resolv:
-      ref: d903fa468e02c2f21521bed9d4d405f8d570c718
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cb5f474500918058a87d97e090e9f88ec6b94e4
-      branch: master
-    pupmod-simp-selinux:
-      ref: 6c78cd99805e521811e1eeafeb8081ce0f0e4f6f
-      branch: master
-    pupmod-simp-simp:
-      ref: 100fc28aaef81d64d2551594199d7c11e73a3580
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 18d943f51fa4b6fe989c07b83c4ef9948402ff81
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 1f7b5d989730d98a01af3bd80e43f316e4226d3a
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: 83a1578b8d39499e79dd4980b117cb92abd43aca
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 762a76cfb445ce251b24fa8077d6cb85e304ed03
-      branch: master
-    pupmod-simp-simp_options:
-      ref: '094c12d8bb02b6def9db5da28484b0b261c9f303'
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: b5ea34dd30285a7ec794b8be8625d4c74c350376
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d3920a27952611b3a15f0a0e43e2e863cad57c7b
-      branch: master
-    pupmod-simp-simplib:
-      ref: f287e1d50f9fceac4a066672e3d70a70ba607997
-      branch: master
-    pupmod-simp-site:
-      ref: aa79efdcd7c22e86fd9a229031344562724d529c
-      branch: master
-    pupmod-simp-ssh:
-      ref: 3fe4ad2e180277bd2ed401137cbdd193b699118c
-      branch: master
-    pupmod-simp-sssd:
-      ref: c0ce3af4ddd69a4f1b99dacacf5e547af2dd8281
-      branch: master
-    pupmod-simp-stunnel:
-      ref: eba656dbe05acd2d7c99230eab89fbfd1b8c3566
-      branch: master
-    pupmod-simp-sudo:
-      ref: bb9a43f70296a83e664807f25023cf731dccf63d
-      branch: master
-    pupmod-simp-sudosh:
-      ref: 484fc7d66328e410c92c1c6771aacafcc9a0e69d
-      branch: master
-    pupmod-simp-svckill:
-      ref: 5d41bd55574d180855d9385bff052b27fd0f4ea6
-      branch: master
-    pupmod-simp-swap:
-      ref: 216e6765fe6a7f8efa6f8c7229f3070d12bc1d9c
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 94256d15349861e256b49b30fbb39e7e3b7634f9
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 843adc44eadf57e6187e2cab86dd5e419236ca14
-      branch: master
-    pupmod-simp-tpm:
-      ref: ed75ad211da65b8712d06758ce66add7d7cba2e6
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7bef9efebdc29f4510133b80e468ccef47fcab19
-      branch: master
-    pupmod-simp-upstart:
-      ref: eb810f4632f97caebd2ad5e4adeb84b5952ceae1
-      branch: master
-    pupmod-simp-vnc:
-      ref: e5fd2bbdaba689d08a088401ddf9d0b3fa85b56c
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: da69c1e9c837225d5bdafb8a6c62ac2f602cd43e
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 7ed32e6b87a3100848ef375084c3c75035018987
-      branch: master
-    pupmod-simp-useradd:
-      ref: 10e78a11c1f157f5fe7acff548df47985d8450e0
-      branch: master
-    puppet-nsswitch:
-      ref: 8cc6c14f6c47efafbf7c9e6ab53832a0c9782728
-      branch: master
-    pupmod-simp-libkv:
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: 83a885843bd62377b59492a3c4e3e20e99f645e9
-    rubygem-simp-rake-helpers:
-      ref: 1bad90681199fa6598fb105899bd6a8c8c523807
-    pkg-r10k:
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        branch: master
+        ref: 172d87e2bc91b0a65c79b7cf06566aa932094362
+      simp-doc:
+        ref: 16559599bfa52e07a7cefdca627937968696ec9b
+        branch: master
+      simp-rsync:
+        ref: ''
+        branch: master
+      pupmod-simp-rsync:
+        ref: 4ba57d001769f8fa54a5e8ff0b5a46253d32bf5f
+        branch: master
+      simp-adapter:
+        ref: eeb6f99fcc84fc512e67079513f3e8711498bc9e
+        branch: master
+      simp-environment:
+        ref: 4a2109c8abc8239ab59f53c4b687485f42ecc0cb
+        branch: master
+      simp-gpgkeys:
+        ref: 6caad667f9a97469f94ec61c11c236509ebe31ed
+        branch: master
+      simp-utils:
+        ref: cd4e69989f0c4cbb83f89eef0367746ab4d36f93
+        branch: master
+      rubygem-simp-cli:
+        ref: dd4ffb348316b05f8d80541a50aa0bc024b8d1a6
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: ''
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: b4bb7f0b89cf4bec2aaffb062f98585086d597fa
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: c10040e9aa83ad5ef425ccedf6ddd94c5a02c2d6
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+      puppetlabs-postgresql:
+        ref: 33baf800f5f433bb51cc0ceb731252c523cf8da5
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+        ref: 1195681a893b3e930e5c06e24bb20200e201d7c5
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+      pupmod-simp-acpid:
+        ref: 58559b46fe16b90623636d887dd65fb498170b6e
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 514fc795997230ba640388a7100c80cb272c7365
+        branch: master
+      pupmod-simp-at:
+        ref: f48bc1fca0588c52e560b5ad73fdf1d1ea6115f1
+        branch: master
+      pupmod-simp-auditd:
+        ref: 833c5887894f4e2aa1d57fc37b81ec3858702eff
+        branch: master
+      pupmod-simp-autofs:
+        ref: 2376e60ff504916e811721991690affc286716b5
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: a70bf2555d8207897f06eb1b89acf49a9dd7add0
+        branch: master
+      pupmod-simp-clamav:
+        ref: 5344b68379d674ea3c533121e76f935661e7149a
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: '06364812bdc24aaf3ae375fddf00bd47a8496699'
+        branch: master
+      pupmod-simp-cron:
+        ref: 33d4f6a3a126366ca0b711c427b12207ff32be43
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 3a3534c6b6be58113a6e1e1804beeaf38de4f4e0
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: 1a75a63a6083d105036bc2d9e4e96ad0f9572bcc
+        branch: master
+      pupmod-simp-fips:
+        ref: 2bea5f763999878f1bc921e9b87289a970fa8ca9
+        branch: master
+      pupmod-simp-freeradius:
+        ref: d540912967a99cba26396854f28946a3776a2859
+        branch: master
+      pupmod-simp-gdm:
+        ref: de354560aa1124823d417230cd8c8e232660f1c6
+        branch: master
+      pupmod-simp-gnome:
+        ref: c2b75953acdd447b9d486bd9afa66b12aead0f8f
+        branch: master
+      puppet-haveged:
+        ref: ''
+        branch: master
+      pupmod-simp-incron:
+        ref: c643a1d2f66f47c35f085f79aa94d607aafc6cd2
+        branch: master
+      pupmod-simp-iptables:
+        ref: '04993ce809070f5f8713ce77ac27101589f99c52'
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: a3e14f8784b5b0b17a63ece8f29908c5065d6762
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: de1a440fb8c45d0415899e726e736158a0413924
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 55290228c4d44dd1731ed10a51bac9b301c911c5
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 0b913a1d1101e05938ada0b67c210b63c8d9a111
+        branch: master
+      pupmod-simp-logrotate:
+        ref: 881dde741e1aa67da6148591e1b40e2248e622ba
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 651c2aa296500c7a44000deecb98216fcf4225f6
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 286cb2db8da152d1077c0936cb2d3d0d7c3bbdbd
+        branch: master
+      pupmod-simp-named:
+        ref: ca6809011f1e688d6e9b0d5c3ddefd6e3d82ef44
+        branch: master
+      pupmod-simp-network:
+        ref: d8ebd3f00515caf0b6ceb7fcc85fcb0ad6b256fb
+        branch: master
+      pupmod-simp-nfs:
+        ref: 690545d7fa83d78f1def0036c3ec2082161dd74f
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 744e7682ea2eaa56329db590a8e2293bfe77baf0
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 1e9befcb907515da0a8f43d86ad7fae1920b571b
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 0baf5b2cf336460913207a87a995518faf011185
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9a3cc5ca8c5b2d81bc248f1ee491c1391c250e61
+        branch: master
+      pupmod-simp-pam:
+        ref: 7a96a927fe898393dca6252b9da91ca130c2db20
+        branch: master
+      pupmod-simp-pki:
+        ref: c081d8cc0d1565e887f65cb41976aa5644bd0880
+        branch: master
+      pupmod-simp-polkit:
+        ref: d23e92ed320ffb41720caa7d864eaa001f38ac9c
+        branch: master
+      pupmod-simp-postfix:
+        ref: ac92dc6f6f410c3119017324adead931f973f71c
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 6f2c1494ead133cb1e20fd9d825f61aa425e74fe
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 15ea0f489d82e80850a28ef4a3a6bc4eb7ce684e
+        branch: master
+      pupmod-simp-resolv:
+        ref: d903fa468e02c2f21521bed9d4d405f8d570c718
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cb5f474500918058a87d97e090e9f88ec6b94e4
+        branch: master
+      pupmod-simp-selinux:
+        ref: 6c78cd99805e521811e1eeafeb8081ce0f0e4f6f
+        branch: master
+      pupmod-simp-simp:
+        ref: 100fc28aaef81d64d2551594199d7c11e73a3580
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 18d943f51fa4b6fe989c07b83c4ef9948402ff81
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 1f7b5d989730d98a01af3bd80e43f316e4226d3a
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: 83a1578b8d39499e79dd4980b117cb92abd43aca
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 762a76cfb445ce251b24fa8077d6cb85e304ed03
+        branch: master
+      pupmod-simp-simp_options:
+        ref: '094c12d8bb02b6def9db5da28484b0b261c9f303'
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: b5ea34dd30285a7ec794b8be8625d4c74c350376
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d3920a27952611b3a15f0a0e43e2e863cad57c7b
+        branch: master
+      pupmod-simp-simplib:
+        ref: f287e1d50f9fceac4a066672e3d70a70ba607997
+        branch: master
+      pupmod-simp-site:
+        ref: aa79efdcd7c22e86fd9a229031344562724d529c
+        branch: master
+      pupmod-simp-ssh:
+        ref: 3fe4ad2e180277bd2ed401137cbdd193b699118c
+        branch: master
+      pupmod-simp-sssd:
+        ref: c0ce3af4ddd69a4f1b99dacacf5e547af2dd8281
+        branch: master
+      pupmod-simp-stunnel:
+        ref: eba656dbe05acd2d7c99230eab89fbfd1b8c3566
+        branch: master
+      pupmod-simp-sudo:
+        ref: bb9a43f70296a83e664807f25023cf731dccf63d
+        branch: master
+      pupmod-simp-sudosh:
+        ref: 484fc7d66328e410c92c1c6771aacafcc9a0e69d
+        branch: master
+      pupmod-simp-svckill:
+        ref: 5d41bd55574d180855d9385bff052b27fd0f4ea6
+        branch: master
+      pupmod-simp-swap:
+        ref: 216e6765fe6a7f8efa6f8c7229f3070d12bc1d9c
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 94256d15349861e256b49b30fbb39e7e3b7634f9
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 843adc44eadf57e6187e2cab86dd5e419236ca14
+        branch: master
+      pupmod-simp-tpm:
+        ref: ed75ad211da65b8712d06758ce66add7d7cba2e6
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7bef9efebdc29f4510133b80e468ccef47fcab19
+        branch: master
+      pupmod-simp-upstart:
+        ref: eb810f4632f97caebd2ad5e4adeb84b5952ceae1
+        branch: master
+      pupmod-simp-vnc:
+        ref: e5fd2bbdaba689d08a088401ddf9d0b3fa85b56c
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: da69c1e9c837225d5bdafb8a6c62ac2f602cd43e
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 7ed32e6b87a3100848ef375084c3c75035018987
+        branch: master
+      pupmod-simp-useradd:
+        ref: 10e78a11c1f157f5fe7acff548df47985d8450e0
+        branch: master
+      puppet-nsswitch:
+        ref: 8cc6c14f6c47efafbf7c9e6ab53832a0c9782728
+        branch: master
+      pupmod-simp-libkv:
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: 83a885843bd62377b59492a3c4e3e20e99f645e9
+      rubygem-simp-rake-helpers:
+        ref: 1bad90681199fa6598fb105899bd6a8c8c523807
+      pkg-r10k:
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/isos.yaml
+++ b/v1/isos.yaml
@@ -1,0 +1,98 @@
+---
+isos:
+  CentOS-7-x86_64-DVD-1804.iso:
+    size: '4470079488'
+    checksum: '506e4e06abf778c3435b4e5745df13e79ebfc86565d7ea1e128067ef6b5a6345'
+    platform: 'CentOS-7.5-x86_64'
+    primary: true
+  CentOS-7-x86_64-DVD-1708.iso:
+    size: '4521459712'
+    checksum: 'ec7500d4b006702af6af023b1f8f1b890b6c7ee54400bb98cef968b883cd6546'
+    platform: 'CentOS-7.4-x86_64'
+    primary: true
+  CentOS-7-x86_64-DVD-1611.iso:
+    size: '4379901952'
+    checksum: 'c455ee948e872ad2194bdddd39045b83634e8613249182b88f549bb2319d97eb'
+    platform: 'CentOS-7.3-x86_64'
+    primary: true
+  CentOS-7-x86_64-DVD-1511.iso:
+    size: '4329570304'
+    checksum: '907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16'
+    platform: 'CentOS-7.2-x86_64'
+    primary: true
+  CentOS-6.10-x86_64-bin-DVD1.iso:
+    size: '3991928832'
+    checksum: 'a68e46970678d4d297d46086ae2efdd3e994322d6d862ff51dcce25a0759e41c'
+    platform: 'CentOS-6.10-x86_64'
+    primary: true
+  CentOS-6.10-x86_64-bin-DVD2.iso:
+    size: '2187548672'
+    checksum: '723ca530171faf29728b8fe7bb6d05ca2ceb6ba9e09d73ed89f2c0ff693e77a5'
+    platform: 'CentOS-6.10-x86_64'
+  CentOS-6.9-x86_64-bin-DVD1.iso:
+    size: '3972005888'
+    checksum: 'd27cf37a40509c17ad70f37bc743f038c1feba00476fe6b69682aa424c399ea6'
+    platform: 'CentOS-6.9-x86_64'
+    primary: true
+  CentOS-6.9-x86_64-bin-DVD2.iso:
+    size: '2177677312'
+    checksum: '631b8640460f46a8139a6a7cbbac5f3594d08c32945449b6bbd65234929ce7a4'
+    platform: 'CentOS-6.9-x86_64'
+  CentOS-6.8-x86_64-bin-DVD1.iso:
+    size: '3916431360'
+    checksum: '1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35'
+    platform: 'CentOS-6.8-x86_64'
+    primary: true
+  CentOS-6.8-x86_64-bin-DVD2.iso:
+    size: '2220693504'
+    checksum: '0aba869427b4ce04e100d72744daf7fea1f7be2e4be56b658095bd9e99e04e6d'
+    platform: 'CentOS-6.8-x86_64'
+  CentOS-6.7-x86_64-bin-DVD1.iso:
+    size: '3895459840'
+    checksum: 'c0c1a05d3d74fb093c6232003da4b22b0680f59d3b2fa2cb7da736bc40b3f2c5'
+    platform: 'CentOS-6.7-x86_64'
+    primary: true
+  CentOS-6.7-x86_64-bin-DVD2.iso:
+    size: '2154524672'
+    checksum: 'f973ac2453af9815d2db944f3c7383bb3061b6b0c12fb58dadf843e1cad67ab6'
+    platform: 'CentOS-6.7-x86_64'
+  rhel-server-7.5-x86_64-dvd.iso:
+    size: '4617928704'
+    checksum: 'd0dd6ae5e001fb050dafefdfd871e7e648b147fb2d35f0e106e0b34a0163e8f5'
+    platform: 'RedHat-7.5-x86_64'
+    primary: true
+  rhel-server-7.4-x86_64-dvd.iso:
+    size: '4059037696'
+    checksum: '431a58c8c0351803a608ffa56948c5a7861876f78ccbe784724dd8c987ff7000'
+    platform: 'RedHat-7.4-x86_64'
+    primary: true
+  rhel-server-7.3-x86_64-dvd.iso:
+    size: '3793747968'
+    checksum: '120acbca7b3d55465eb9f8ef53ad7365f2997d42d4f83d7cc285bf5c71e1131f'
+    platform: 'RedHat-7.3-x86_64'
+    primary: true
+  rhel-server-7.2-x86_64-dvd.iso:
+    size: '4043309056'
+    checksum: '03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5'
+    platform: 'RedHat-7.2-x86_64'
+    primary: true
+  rhel-server-6.10-x86_64-dvd.iso:
+    size: '3895459840'
+    checksum: '1e15f9202d2cdd4b2bdf9d6503a8543347f0cb8cc06ba9a0dfd2df4fdef5c727'
+    platform: 'RedHat-6.10-x86_64'
+    primary: true
+  rhel-server-6.9-x86_64-dvd.iso:
+    size: '3887071232'
+    checksum: '3f961576e9f81ea118566f73f98d7bdf3287671c35436a13787c1ffd5078cf8e'
+    platform: 'RedHat-6.9-x86_64'
+    primary: true
+  rhel-server-6.8-x86_64-dvd.iso:
+    size: '3878682624'
+    checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
+    platform: 'RedHat-6.8-x86_64'
+    primary: true
+  rhel-server-6.7-x86_64-dvd.iso:
+    size: '3841982464'
+    checksum: '0e0acb2a544f4d58f10292144161f40439734c6e98b13ba8c595372b20354bc5'
+    platform: 'RedHat-6.7-x86_64'
+    primary: true

--- a/v1/nightlies/nightly-2018-02-05.yaml
+++ b/v1/nightlies/nightly-2018-02-05.yaml
@@ -1,352 +1,357 @@
 ---
 releases:
   nightly-2018-02-05:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-06.yaml
+++ b/v1/nightlies/nightly-2018-02-06.yaml
@@ -1,353 +1,358 @@
 ---
 releases:
   nightly-2018-02-06:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-07.yaml
+++ b/v1/nightlies/nightly-2018-02-07.yaml
@@ -1,353 +1,358 @@
 ---
 releases:
   nightly-2018-02-07:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-08.yaml
+++ b/v1/nightlies/nightly-2018-02-08.yaml
@@ -1,356 +1,361 @@
 ---
 releases:
   nightly-2018-02-08:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: 5.2.1
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: 5.2.1
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-09.yaml
+++ b/v1/nightlies/nightly-2018-02-09.yaml
@@ -1,356 +1,361 @@
 ---
 releases:
   nightly-2018-02-09:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: 5.2.1
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: 5.2.1
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 3fbf78b14c28c76153a8da0f0337ff1c34e6538e
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-18.yaml
+++ b/v1/nightlies/nightly-2018-02-18.yaml
@@ -1,360 +1,365 @@
 ---
 releases:
   nightly-2018-02-18:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: ec2403fb738f316cc8536ce5ce339f6827282cfa
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: 5.2.1
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: 71a8a259f6e95723854042587867241d5fae8bf2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 7ab9a4480c824d4c34ff3c1330d6935afdc61789
-      tag: 0.3.0
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: ec2403fb738f316cc8536ce5ce339f6827282cfa
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: 5.2.1
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: 71a8a259f6e95723854042587867241d5fae8bf2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 7ab9a4480c824d4c34ff3c1330d6935afdc61789
+        tag: 0.3.0
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-19.yaml
+++ b/v1/nightlies/nightly-2018-02-19.yaml
@@ -1,360 +1,365 @@
 ---
 releases:
   nightly-2018-02-19:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: ec2403fb738f316cc8536ce5ce339f6827282cfa
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: 5.2.1
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: 71a8a259f6e95723854042587867241d5fae8bf2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 7ab9a4480c824d4c34ff3c1330d6935afdc61789
-      tag: 0.3.0
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: ec2403fb738f316cc8536ce5ce339f6827282cfa
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: 5.2.1
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: 71a8a259f6e95723854042587867241d5fae8bf2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 7ab9a4480c824d4c34ff3c1330d6935afdc61789
+        tag: 0.3.0
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-20.yaml
+++ b/v1/nightlies/nightly-2018-02-20.yaml
@@ -1,360 +1,365 @@
 ---
 releases:
   nightly-2018-02-20:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: ec2403fb738f316cc8536ce5ce339f6827282cfa
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: 5.2.1
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: 71a8a259f6e95723854042587867241d5fae8bf2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 7ab9a4480c824d4c34ff3c1330d6935afdc61789
-      tag: 0.3.0
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: ec2403fb738f316cc8536ce5ce339f6827282cfa
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: 5.2.1
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: 71a8a259f6e95723854042587867241d5fae8bf2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 7ab9a4480c824d4c34ff3c1330d6935afdc61789
+        tag: 0.3.0
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-21.yaml
+++ b/v1/nightlies/nightly-2018-02-21.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-02-21:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: 71a8a259f6e95723854042587867241d5fae8bf2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: ed26e0d46666de2644a5f90b049cb48434177143
-      tag: 0.3.3
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: 71a8a259f6e95723854042587867241d5fae8bf2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: ed26e0d46666de2644a5f90b049cb48434177143
+        tag: 0.3.3
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-22.yaml
+++ b/v1/nightlies/nightly-2018-02-22.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-02-22:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: 71a8a259f6e95723854042587867241d5fae8bf2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: a06392d6b4a97d99d236c7997e14095dc052910a
-      tag: 0.3.4
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: 71a8a259f6e95723854042587867241d5fae8bf2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: a06392d6b4a97d99d236c7997e14095dc052910a
+        tag: 0.3.4
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-23.yaml
+++ b/v1/nightlies/nightly-2018-02-23.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-02-23:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: 71a8a259f6e95723854042587867241d5fae8bf2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: dd20ab6e6cca10fd18df3c83653636d262bad7a8
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 7f76be45a080fc76aeb2f8a71ca3af5a64114f54
-      tag: 0.3.5
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: 71a8a259f6e95723854042587867241d5fae8bf2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: dd20ab6e6cca10fd18df3c83653636d262bad7a8
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 7f76be45a080fc76aeb2f8a71ca3af5a64114f54
+        tag: 0.3.5
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-26.yaml
+++ b/v1/nightlies/nightly-2018-02-26.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-02-26:
-    simp-doc:
-      ref: 8277eab0a38f3c995a762e017fe0cc65c7ac3bb8
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: d7abe19fc11cdfff5062aea1802dee050df568a2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: dd20ab6e6cca10fd18df3c83653636d262bad7a8
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 8277eab0a38f3c995a762e017fe0cc65c7ac3bb8
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: d7abe19fc11cdfff5062aea1802dee050df568a2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: dd20ab6e6cca10fd18df3c83653636d262bad7a8
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: ea88d6c27a4190f8a37b68bad7f5d8a258565ce2
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-27.yaml
+++ b/v1/nightlies/nightly-2018-02-27.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-02-27:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: d7abe19fc11cdfff5062aea1802dee050df568a2
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: dd20ab6e6cca10fd18df3c83653636d262bad7a8
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: 9a6066c679cfe013b6260285445669c8660406b6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: d7abe19fc11cdfff5062aea1802dee050df568a2
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: dd20ab6e6cca10fd18df3c83653636d262bad7a8
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: 9a6066c679cfe013b6260285445669c8660406b6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 7264bbe933ab8ec3749757c6c2629dfaf24565de
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-02-28.yaml
+++ b/v1/nightlies/nightly-2018-02-28.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-02-28:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: 1270603b7fca596ab6c25a6db09738753e29c325
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2eaa8d599377a84ff63357f492e80a309ce479dd
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: 1270603b7fca596ab6c25a6db09738753e29c325
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2eaa8d599377a84ff63357f492e80a309ce479dd
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-01.yaml
+++ b/v1/nightlies/nightly-2018-03-01.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-03-01:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: 1270603b7fca596ab6c25a6db09738753e29c325
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2eaa8d599377a84ff63357f492e80a309ce479dd
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: 1270603b7fca596ab6c25a6db09738753e29c325
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2eaa8d599377a84ff63357f492e80a309ce479dd
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: 613339fcb3fe51d695375cd2b1718913e56aaf80
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-02.yaml
+++ b/v1/nightlies/nightly-2018-03-02.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-03-02:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
-      branch: master
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      branch: master
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      branch: master
-    pupmod-simp-pki:
-      ref: 69cce30a56fe138677303dfabb042e89aa24856c
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      branch: master
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      branch: master
-    pupmod-simp-sssd:
-      ref: 1270603b7fca596ab6c25a6db09738753e29c325
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      branch: master
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 2eaa8d599377a84ff63357f492e80a309ce479dd
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: 39e48321f425797bdf1c20097c150d703896032f
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 87f738a714637d8bed79b6e81401f24bafbda9a8
+        branch: master
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        branch: master
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        branch: master
+      pupmod-simp-pki:
+        ref: 69cce30a56fe138677303dfabb042e89aa24856c
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        branch: master
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 8cea1341f874c8d15ab7cc3b8b2a9cc28751b442
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        branch: master
+      pupmod-simp-sssd:
+        ref: 1270603b7fca596ab6c25a6db09738753e29c325
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        branch: master
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 2eaa8d599377a84ff63357f492e80a309ce479dd
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: d5c16d335aa6757d6065e4c0dfc3aabf0a347b4d
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: 39e48321f425797bdf1c20097c150d703896032f
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-05.yaml
+++ b/v1/nightlies/nightly-2018-03-05.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-05:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-06.yaml
+++ b/v1/nightlies/nightly-2018-03-06.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-06:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-07.yaml
+++ b/v1/nightlies/nightly-2018-03-07.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-07:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-08.yaml
+++ b/v1/nightlies/nightly-2018-03-08.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-08:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 6424f5745940d0996da4a0d09c5c3c5acccbcf3c
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-09.yaml
+++ b/v1/nightlies/nightly-2018-03-09.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-09:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      version: latest
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        version: latest
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-12.yaml
+++ b/v1/nightlies/nightly-2018-03-12.yaml
@@ -1,361 +1,366 @@
 ---
 releases:
   nightly-2018-03-12:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-13.yaml
+++ b/v1/nightlies/nightly-2018-03-13.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-13:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: 81c5ad347eec5da04a160fff83780d185915138b
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 45e99da3087da21df1f2af0ceaaae7c170e80180
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: bda9648a8c088e30dccc3f065339d1cf9efd5f70
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: 81c5ad347eec5da04a160fff83780d185915138b
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-14.yaml
+++ b/v1/nightlies/nightly-2018-03-14.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-14:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 4433e7814210c63cc624e3038d4ec6889468be60
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: 8be55e11cacf1ce7de0c42d77a0b51c0f7498915
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 893fdb91c653d53ad4686aeb35c39357e38e4ac5
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: e8998361d79dfdaeb45dd81df941f3931d7c2669
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: c85a1f9d7d861f45fc5ba513131c9b894c341a87
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 4433e7814210c63cc624e3038d4ec6889468be60
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: 8be55e11cacf1ce7de0c42d77a0b51c0f7498915
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-15.yaml
+++ b/v1/nightlies/nightly-2018-03-15.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-15:
-    simp-doc:
-      ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 03f4295d17d301b26c23333889c43268114fd49f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: 56969e9c67c830084e21cda507679432271b398c
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: 30f0a47f011d850e16679a28266fb6e39143c565
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: 8be55e11cacf1ce7de0c42d77a0b51c0f7498915
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 1ecd785164eb9508c28007ea04dbf7bce15bad3d
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: b2c4b91790e47d0d4a3b7b79d2a912e70b8b3537
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: 419b8f401aabb705473d8a5e5c55d4f0cd8bf5e6
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 03f4295d17d301b26c23333889c43268114fd49f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: 56969e9c67c830084e21cda507679432271b398c
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: 30f0a47f011d850e16679a28266fb6e39143c565
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: 8be55e11cacf1ce7de0c42d77a0b51c0f7498915
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-16.yaml
+++ b/v1/nightlies/nightly-2018-03-16.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-16:
-    simp-doc:
-      ref: 767b019c954a8cad4db2f57a7d4f53a578681f20
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 33604987592a78ce1bd608672ba9fc18c00d3367
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: d5e049ed6777b9942575266a440f8f5e1587acf9
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: 56969e9c67c830084e21cda507679432271b398c
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: 8be55e11cacf1ce7de0c42d77a0b51c0f7498915
-      tag: 0.3.7
-    rubygem-simp-rake-helpers:
-      ref: a83f2165b010f4d93114c7432166e597c171aeac
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 767b019c954a8cad4db2f57a7d4f53a578681f20
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 33604987592a78ce1bd608672ba9fc18c00d3367
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: d5e049ed6777b9942575266a440f8f5e1587acf9
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: 56969e9c67c830084e21cda507679432271b398c
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: 8be55e11cacf1ce7de0c42d77a0b51c0f7498915
+        tag: 0.3.7
+      rubygem-simp-rake-helpers:
+        ref: a83f2165b010f4d93114c7432166e597c171aeac
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-19.yaml
+++ b/v1/nightlies/nightly-2018-03-19.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-19:
-    simp-doc:
-      ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 33604987592a78ce1bd608672ba9fc18c00d3367
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: af1fae067f28fb896dbcdebbf0e69bdb432e46d9
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
-      tag: 0.3.11
-    rubygem-simp-rake-helpers:
-      ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 2b10e348dbea648e9379bb82f1e6aacafcb1ab9a
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 33604987592a78ce1bd608672ba9fc18c00d3367
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: af1fae067f28fb896dbcdebbf0e69bdb432e46d9
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
+        tag: 0.3.11
+      rubygem-simp-rake-helpers:
+        ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-20.yaml
+++ b/v1/nightlies/nightly-2018-03-20.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-20:
-    simp-doc:
-      ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: ee4b0a33d51833d1e867d6ab3adc2017a7e0043f
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: af1fae067f28fb896dbcdebbf0e69bdb432e46d9
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
-      tag: 0.3.11
-    rubygem-simp-rake-helpers:
-      ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: ee4b0a33d51833d1e867d6ab3adc2017a7e0043f
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: af1fae067f28fb896dbcdebbf0e69bdb432e46d9
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
+        tag: 0.3.11
+      rubygem-simp-rake-helpers:
+        ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-21.yaml
+++ b/v1/nightlies/nightly-2018-03-21.yaml
@@ -1,362 +1,367 @@
 ---
 releases:
   nightly-2018-03-21:
-    simp-doc:
-      ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: a6f3ddda55a23536ec25c0e0becb0ea0f89de435
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
-      tag: 0.3.11
-    rubygem-simp-rake-helpers:
-      ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: a6f3ddda55a23536ec25c0e0becb0ea0f89de435
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
+        tag: 0.3.11
+      rubygem-simp-rake-helpers:
+        ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-22.yaml
+++ b/v1/nightlies/nightly-2018-03-22.yaml
@@ -1,363 +1,368 @@
 ---
 releases:
   nightly-2018-03-22:
-    simp-doc:
-      ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 88009f92b670ab222625fde75b5cd13304451a70
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
-      tag: 0.3.11
-    rubygem-simp-rake-helpers:
-      ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 88009f92b670ab222625fde75b5cd13304451a70
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
+        tag: 0.3.11
+      rubygem-simp-rake-helpers:
+        ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-23.yaml
+++ b/v1/nightlies/nightly-2018-03-23.yaml
@@ -1,363 +1,368 @@
 ---
 releases:
   nightly-2018-03-23:
-    simp-doc:
-      ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 88009f92b670ab222625fde75b5cd13304451a70
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
-      tag: 0.3.11
-    rubygem-simp-rake-helpers:
-      ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 88009f92b670ab222625fde75b5cd13304451a70
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
+        tag: 0.3.11
+      rubygem-simp-rake-helpers:
+        ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-03-26.yaml
+++ b/v1/nightlies/nightly-2018-03-26.yaml
@@ -1,363 +1,368 @@
 ---
 releases:
   nightly-2018-03-26:
-    simp-doc:
-      ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: '05933e092c3bb121347d966f1cb80532db676a8e'
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-      tag: simp-2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-      tag: simp-2.2.3
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
-      branch: master
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: 88009f92b670ab222625fde75b5cd13304451a70
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-    pupmod-simp-simp:
-      ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 81880a52e31fa5979791001f3302c78b29091369
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-sssd:
-      ref: 20634ad343630f44c1c72e33b901ff2d555341e6
-      branch: master
-    pupmod-simp-stunnel:
-      ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
-      tag: 0.3.11
-    rubygem-simp-rake-helpers:
-      ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
-      tag: 5.4.1
+    components:
+      simp-doc:
+        ref: 0e544b7516e981ccadbe25c91a4d1dee7a9b3ba4
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: '05933e092c3bb121347d966f1cb80532db676a8e'
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+        tag: simp-2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+        tag: simp-2.2.3
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 7a01a3bf24576f2b6244d135c674a35de87b660e
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 9b895dd34fafe7db7f6062aa1d813ed975ceac43
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 05d052f4ba8b4ac25715953875ebddcdb744b804
+        branch: master
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: 88009f92b670ab222625fde75b5cd13304451a70
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+      pupmod-simp-simp:
+        ref: 35a71f0b2fe2fa7e0399cd1919021d5a8a655119
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: 0d41ec44cb3cdb621cd42a1d8c5f8749bcbb3ba1
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 81880a52e31fa5979791001f3302c78b29091369
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-sssd:
+        ref: 20634ad343630f44c1c72e33b901ff2d555341e6
+        branch: master
+      pupmod-simp-stunnel:
+        ref: f99153d299a497c21dda55c0c8568bf3c2c0fa1b
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: f0bcacbbfc52aa2675f66f8d540811ffe2c06b9d
+        tag: 0.3.11
+      rubygem-simp-rake-helpers:
+        ref: 162a233774e5f0ecffc802c90103b1ddeceaf691
+        tag: 5.4.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-02.yaml
+++ b/v1/nightlies/nightly-2018-05-02.yaml
@@ -1,355 +1,360 @@
 ---
 releases:
   nightly-2018-05-02:
-    simp-doc:
-      ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
-      branch: master
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: 3662862e38b9a22e62ceb7c4014a70ceb87605e0
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
-      branch: master
-    pupmod-simp-pki:
-      ref: 8187269864a909d28d0d2f44025da7f92697e6d3
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: f1c4f556b23fe5524810e6f413509b23694ac4de
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-    pupmod-simp-simp:
-      ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 77fac27f0dd44c377e3a6976cbda05703806221d
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
-    rubygem-simp-rake-helpers:
-      ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    components:
+      simp-doc:
+        ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
+        branch: master
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: 3662862e38b9a22e62ceb7c4014a70ceb87605e0
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
+        branch: master
+      pupmod-simp-pki:
+        ref: 8187269864a909d28d0d2f44025da7f92697e6d3
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: f1c4f556b23fe5524810e6f413509b23694ac4de
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+      pupmod-simp-simp:
+        ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 77fac27f0dd44c377e3a6976cbda05703806221d
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
+      rubygem-simp-rake-helpers:
+        ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-03.yaml
+++ b/v1/nightlies/nightly-2018-05-03.yaml
@@ -1,355 +1,360 @@
 ---
 releases:
   nightly-2018-05-03:
-    simp-doc:
-      ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
-      branch: master
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: 72292dd87e0b1b1fdcd9cb30b0204a336ecc3b4e
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
-      branch: master
-    pupmod-simp-pki:
-      ref: 8187269864a909d28d0d2f44025da7f92697e6d3
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: f1c4f556b23fe5524810e6f413509b23694ac4de
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-    pupmod-simp-simp:
-      ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 77fac27f0dd44c377e3a6976cbda05703806221d
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
-    rubygem-simp-rake-helpers:
-      ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    components:
+      simp-doc:
+        ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
+        branch: master
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: 72292dd87e0b1b1fdcd9cb30b0204a336ecc3b4e
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
+        branch: master
+      pupmod-simp-pki:
+        ref: 8187269864a909d28d0d2f44025da7f92697e6d3
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: f1c4f556b23fe5524810e6f413509b23694ac4de
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+      pupmod-simp-simp:
+        ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 77fac27f0dd44c377e3a6976cbda05703806221d
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
+      rubygem-simp-rake-helpers:
+        ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-04.yaml
+++ b/v1/nightlies/nightly-2018-05-04.yaml
@@ -1,355 +1,360 @@
 ---
 releases:
   nightly-2018-05-04:
-    simp-doc:
-      ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
-      branch: master
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: 72292dd87e0b1b1fdcd9cb30b0204a336ecc3b4e
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-    pupmod-simp-iptables:
-      ref: cf5235658426bebd4d35436b88db3ace42307599
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
-      branch: master
-    pupmod-simp-pki:
-      ref: 8187269864a909d28d0d2f44025da7f92697e6d3
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: f1c4f556b23fe5524810e6f413509b23694ac4de
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-    pupmod-simp-simp:
-      ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 77fac27f0dd44c377e3a6976cbda05703806221d
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
-    rubygem-simp-rake-helpers:
-      ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    components:
+      simp-doc:
+        ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
+        branch: master
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: 72292dd87e0b1b1fdcd9cb30b0204a336ecc3b4e
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+      pupmod-simp-iptables:
+        ref: cf5235658426bebd4d35436b88db3ace42307599
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
+        branch: master
+      pupmod-simp-pki:
+        ref: 8187269864a909d28d0d2f44025da7f92697e6d3
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: f1c4f556b23fe5524810e6f413509b23694ac4de
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+      pupmod-simp-simp:
+        ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 77fac27f0dd44c377e3a6976cbda05703806221d
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
+      rubygem-simp-rake-helpers:
+        ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-07.yaml
+++ b/v1/nightlies/nightly-2018-05-07.yaml
@@ -1,355 +1,360 @@
 ---
 releases:
   nightly-2018-05-07:
-    simp-doc:
-      ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
-      branch: master
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-      branch: master
-    pupmod-simp-rsync:
-      ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
-      branch: master
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      branch: master
-    simp-environment:
-      ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
-      branch: master
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      branch: master
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      branch: master
-    rubygem-simp-cli:
-      ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
-      branch: master
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      branch: master
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-    puppet-elasticsearch:
-      tag: 5.2.0
-      branch: master
-    puppet-logstash:
-      tag: 5.2.1
-      branch: master
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      branch: master
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      branch: master
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      branch: master
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      branch: master
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      branch: master
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      branch: master
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      branch: master
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      branch: master
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      branch: master
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      branch: master
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-    puppetlabs-apache:
-      ref: e587f2af793111adab04bb776808f99a09ca092b
-      branch: master
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      branch: master
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      branch: master
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      branch: master
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      branch: master
-    puppetlabs-puppet_authorization:
-      ref: master
-      branch: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      branch: master
-    puppetlabs-mysql:
-      ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
-      branch: master
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      branch: master
-    puppetlabs-stdlib:
-      tag: 4.19.0
-      branch: master
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      branch: master
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      branch: master
-    pupmod-simp-activemq:
-      ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
-      branch: master
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      branch: master
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-    pupmod-simp-auditd:
-      ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
-      branch: master
-    pupmod-simp-autofs:
-      ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
-      branch: master
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      branch: master
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      branch: master
-    pupmod-simp-compliance_markup:
-      ref: 6ab6f22033f4ec52098d177ec126f3244e7fa8d7
-      branch: master
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      branch: master
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      branch: master
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      branch: master
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-    pupmod-simp-freeradius:
-      ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
-      branch: master
-    pupmod-simp-gdm:
-      ref: 14294631dd94a014214e136cac373041082dd09e
-      branch: master
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      branch: master
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      branch: master
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-    pupmod-simp-iptables:
-      ref: cf5235658426bebd4d35436b88db3ace42307599
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      branch: master
-    pupmod-simp-jenkins:
-      ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
-      branch: master
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      branch: master
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      branch: master
-    pupmod-simp-libreswan:
-      ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
-      branch: master
-    pupmod-simp-libvirt:
-      ref: bdc6176b2c11634b755f196c4ea48e175681a598
-      branch: master
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      branch: master
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      branch: master
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      branch: master
-    pupmod-simp-mozilla:
-      ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
-      branch: master
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      branch: master
-    pupmod-simp-nfs:
-      ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
-      branch: master
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      branch: master
-    pupmod-simp-simp_openldap:
-      ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
-      branch: master
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      branch: master
-    pupmod-simp-pam:
-      ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
-      branch: master
-    pupmod-simp-pki:
-      ref: 8187269864a909d28d0d2f44025da7f92697e6d3
-      branch: master
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      branch: master
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-    pupmod-simp-pupmod:
-      ref: f1c4f556b23fe5524810e6f413509b23694ac4de
-      branch: master
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      branch: master
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      branch: master
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-    pupmod-simp-simp:
-      ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
-      branch: master
-    pupmod-simp-simpcat:
-      ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
-      branch: master
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      branch: master
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-    pupmod-simp-simp_nfs:
-      ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
-      branch: master
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      branch: master
-    pupmod-simp-simplib:
-      ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
-      branch: master
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      branch: master
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-    pupmod-simp-stunnel:
-      ref: 77fac27f0dd44c377e3a6976cbda05703806221d
-      branch: master
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-    pupmod-simp-sudosh:
-      ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
-      branch: master
-    pupmod-simp-svckill:
-      ref: cf7f2129309723275714ede9fc2e709588669007
-      branch: master
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      branch: master
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      branch: master
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-    pupmod-simp-tpm:
-      ref: 858194088b35c4d43f7d1aba94bf12302083e89d
-      branch: master
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      branch: master
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      branch: master
-    pupmod-simp-vnc:
-      ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
-      branch: master
-    pupmod-simp-vsftpd:
-      ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
-      branch: master
-    pupmod-simp-xinetd:
-      ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
-      branch: master
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      branch: master
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-    pupmod-simp-libkv:
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: c1d87dc396b71146ac9e37557c3d7f841087d319
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      compiled: true
-      ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
-    rubygem-simp-rake-helpers:
-      ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    components:
+      simp-doc:
+        ref: b48525c617b045e4e1ae2dd219240eaf80910fe9
+        branch: master
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+        branch: master
+      pupmod-simp-rsync:
+        ref: 0b9dda3625d102967fb80cc956ee309c3b69f135
+        branch: master
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        branch: master
+      simp-environment:
+        ref: e07f8666e8cbc37fa29dc26b562f345768a885bd
+        branch: master
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        branch: master
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        branch: master
+      rubygem-simp-cli:
+        ref: 9ae016259b38bbee4b8b2dcda270e55b51873473
+        branch: master
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        branch: master
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+      puppet-elasticsearch:
+        tag: 5.2.0
+        branch: master
+      puppet-logstash:
+        tag: 5.2.1
+        branch: master
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        branch: master
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        branch: master
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        branch: master
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        branch: master
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        branch: master
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        branch: master
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        branch: master
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        branch: master
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        branch: master
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        branch: master
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+      puppetlabs-apache:
+        ref: e587f2af793111adab04bb776808f99a09ca092b
+        branch: master
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        branch: master
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        branch: master
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        branch: master
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        branch: master
+      puppetlabs-puppet_authorization:
+        ref: master
+        branch: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        branch: master
+      puppetlabs-mysql:
+        ref: a5497b2bcf9098ed707348193bb7ff2e4ef1e543
+        branch: master
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        branch: master
+      puppetlabs-stdlib:
+        tag: 4.19.0
+        branch: master
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        branch: master
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        branch: master
+      pupmod-simp-activemq:
+        ref: 9698bf5ad5263f4895bfd19b7736f2bee0a30baa
+        branch: master
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        branch: master
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+      pupmod-simp-auditd:
+        ref: 9b7743581df5d22a2eff89b065c6ea4670743afc
+        branch: master
+      pupmod-simp-autofs:
+        ref: 03dc56021d5ea0735bd17c4e954b38a049efc36d
+        branch: master
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        branch: master
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        branch: master
+      pupmod-simp-compliance_markup:
+        ref: 6ab6f22033f4ec52098d177ec126f3244e7fa8d7
+        branch: master
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        branch: master
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        branch: master
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        branch: master
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+      pupmod-simp-freeradius:
+        ref: 1ef6cc8d3cfa4581ced656b20bd88d0e04b9538f
+        branch: master
+      pupmod-simp-gdm:
+        ref: 14294631dd94a014214e136cac373041082dd09e
+        branch: master
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        branch: master
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        branch: master
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+      pupmod-simp-iptables:
+        ref: cf5235658426bebd4d35436b88db3ace42307599
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        branch: master
+      pupmod-simp-jenkins:
+        ref: 3d5ada01a30a2e0021c858ab9271f14a9e2db365
+        branch: master
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        branch: master
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        branch: master
+      pupmod-simp-libreswan:
+        ref: 87cb0bec0e7d32325bde4e4a2f2c82d5f4477d0c
+        branch: master
+      pupmod-simp-libvirt:
+        ref: bdc6176b2c11634b755f196c4ea48e175681a598
+        branch: master
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        branch: master
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        branch: master
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        branch: master
+      pupmod-simp-mozilla:
+        ref: 1cc5e45c2d10ff2aed59b68a7f02887a436e4104
+        branch: master
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        branch: master
+      pupmod-simp-nfs:
+        ref: 8dbe15d8ab398b21b3a726c188b1246be00f8316
+        branch: master
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        branch: master
+      pupmod-simp-simp_openldap:
+        ref: ea964ecf68ce5426480f2338ebcb3e053cbb4298
+        branch: master
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        branch: master
+      pupmod-simp-pam:
+        ref: 266bcecb34259a7bb385ab246f7a10900dc284a4
+        branch: master
+      pupmod-simp-pki:
+        ref: 8187269864a909d28d0d2f44025da7f92697e6d3
+        branch: master
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        branch: master
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+      pupmod-simp-pupmod:
+        ref: f1c4f556b23fe5524810e6f413509b23694ac4de
+        branch: master
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        branch: master
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        branch: master
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+      pupmod-simp-simp:
+        ref: cf8670e1f70fb711ff882c6ede7db992e006b36a
+        branch: master
+      pupmod-simp-simpcat:
+        ref: eeaa2e7e7f14c45f9b6a3f83c1fec86f03d41864
+        branch: master
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        branch: master
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+      pupmod-simp-simp_nfs:
+        ref: c6162be77e2524714b797c7cbd7916dd7ccab8be
+        branch: master
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        branch: master
+      pupmod-simp-simplib:
+        ref: 04f1f82be4f4b3e3173098592b3bafa256c2769d
+        branch: master
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        branch: master
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+      pupmod-simp-stunnel:
+        ref: 77fac27f0dd44c377e3a6976cbda05703806221d
+        branch: master
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+      pupmod-simp-sudosh:
+        ref: aebefa9af889d5289b13150719cb0fa4ccceee6a
+        branch: master
+      pupmod-simp-svckill:
+        ref: cf7f2129309723275714ede9fc2e709588669007
+        branch: master
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        branch: master
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        branch: master
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+      pupmod-simp-tpm:
+        ref: 858194088b35c4d43f7d1aba94bf12302083e89d
+        branch: master
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        branch: master
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        branch: master
+      pupmod-simp-vnc:
+        ref: 873815f2d3169d3e2f4106dce63b124f7bc0d24b
+        branch: master
+      pupmod-simp-vsftpd:
+        ref: adb91f66db804b8ba2c7cf4ec0e8efd781a84e88
+        branch: master
+      pupmod-simp-xinetd:
+        ref: 74be77b849e78a71fafc7a7035cbafa35163bd7e
+        branch: master
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        branch: master
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+      pupmod-simp-libkv:
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: c1d87dc396b71146ac9e37557c3d7f841087d319
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        compiled: true
+        ref: b99e87c71fc2761b0c1ebfd2733e6a22a006e013
+      rubygem-simp-rake-helpers:
+        ref: a8820b38ff84dccdd1204326aa55d18c610a3051
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-08.yaml
+++ b/v1/nightlies/nightly-2018-05-08.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-08:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: a5e9704b594152163bcff48bc759b702914ee5a5
-      branch: master
-      tag: 2.0.2
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: 5e2d464cee5ee723c4835b7524e4faca591cee8e
-      branch: master
-      tag: 3.0.0
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: f75319e10ac9ee51e5b489b1ddd5a514c6f180ee
-      branch: master
-      tag: 2.0.4
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 295de2b48986e3033d01da0de0fa6650a8870849
-      branch: master
-      tag: 2.2.2
-    augeasproviders_ssh:
-      ref: b6268b38b6931ecb9f5a641d42f7cd9bbac530cf
-      branch: master
-      tag: 2.5.3
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6160665065be2720b491534d96b62f397ca1d17b
-      branch: master
-      tag: 1.7.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.2.1
-    puppetlabs-stdlib:
-      tag: 4.24.0
-      branch: master
-      ref: e46d9a4c144cbe3e979f1684d89f577f43fe9084
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: e57ab7ef954a98dd9021441a7acb66eed64b4efd
-      branch: master
-      tag: 4.4.1
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-      tag: 1.0.5
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: fcd4f48bc7fc8166308e9cd317b7eb21c2981c44
-      tag: 0.4.0
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: a5e9704b594152163bcff48bc759b702914ee5a5
+        branch: master
+        tag: 2.0.2
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: 5e2d464cee5ee723c4835b7524e4faca591cee8e
+        branch: master
+        tag: 3.0.0
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: f75319e10ac9ee51e5b489b1ddd5a514c6f180ee
+        branch: master
+        tag: 2.0.4
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 295de2b48986e3033d01da0de0fa6650a8870849
+        branch: master
+        tag: 2.2.2
+      augeasproviders_ssh:
+        ref: b6268b38b6931ecb9f5a641d42f7cd9bbac530cf
+        branch: master
+        tag: 2.5.3
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6160665065be2720b491534d96b62f397ca1d17b
+        branch: master
+        tag: 1.7.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.2.1
+      puppetlabs-stdlib:
+        tag: 4.24.0
+        branch: master
+        ref: e46d9a4c144cbe3e979f1684d89f577f43fe9084
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: e57ab7ef954a98dd9021441a7acb66eed64b4efd
+        branch: master
+        tag: 4.4.1
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+        tag: 1.0.5
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: fcd4f48bc7fc8166308e9cd317b7eb21c2981c44
+        tag: 0.4.0
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-09.yaml
+++ b/v1/nightlies/nightly-2018-05-09.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-09:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: a5e9704b594152163bcff48bc759b702914ee5a5
-      branch: master
-      tag: 2.0.2
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: 5e2d464cee5ee723c4835b7524e4faca591cee8e
-      branch: master
-      tag: 3.0.0
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: f75319e10ac9ee51e5b489b1ddd5a514c6f180ee
-      branch: master
-      tag: 2.0.4
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 295de2b48986e3033d01da0de0fa6650a8870849
-      branch: master
-      tag: 2.2.2
-    augeasproviders_ssh:
-      ref: b6268b38b6931ecb9f5a641d42f7cd9bbac530cf
-      branch: master
-      tag: 2.5.3
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6160665065be2720b491534d96b62f397ca1d17b
-      branch: master
-      tag: 1.7.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.2.1
-    puppetlabs-stdlib:
-      tag: 4.24.0
-      branch: master
-      ref: e46d9a4c144cbe3e979f1684d89f577f43fe9084
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 7494ecd921ba890da84a7fa4a0678d7337e55d65
-      branch: master
-      tag: simp-simp
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-      tag: 1.0.5
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 262f6d10276fdf461a992f530947018e6f38d931
-      tag: 0.4.1
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: a5e9704b594152163bcff48bc759b702914ee5a5
+        branch: master
+        tag: 2.0.2
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: 5e2d464cee5ee723c4835b7524e4faca591cee8e
+        branch: master
+        tag: 3.0.0
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: f75319e10ac9ee51e5b489b1ddd5a514c6f180ee
+        branch: master
+        tag: 2.0.4
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 295de2b48986e3033d01da0de0fa6650a8870849
+        branch: master
+        tag: 2.2.2
+      augeasproviders_ssh:
+        ref: b6268b38b6931ecb9f5a641d42f7cd9bbac530cf
+        branch: master
+        tag: 2.5.3
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6160665065be2720b491534d96b62f397ca1d17b
+        branch: master
+        tag: 1.7.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.2.1
+      puppetlabs-stdlib:
+        tag: 4.24.0
+        branch: master
+        ref: e46d9a4c144cbe3e979f1684d89f577f43fe9084
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 7494ecd921ba890da84a7fa4a0678d7337e55d65
+        branch: master
+        tag: simp-simp
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+        tag: 1.0.5
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 262f6d10276fdf461a992f530947018e6f38d931
+        tag: 0.4.1
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-10.yaml
+++ b/v1/nightlies/nightly-2018-05-10.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-10:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-11.yaml
+++ b/v1/nightlies/nightly-2018-05-11.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-11:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-14.yaml
+++ b/v1/nightlies/nightly-2018-05-14.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-14:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-15.yaml
+++ b/v1/nightlies/nightly-2018-05-15.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-15:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-16.yaml
+++ b/v1/nightlies/nightly-2018-05-16.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-16:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 3f432205c3467b4614de47f488b1f94646bc3426
-      branch: master
-      tag: v4.1.2-enterprise
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 3f432205c3467b4614de47f488b1f94646bc3426
+        branch: master
+        tag: v4.1.2-enterprise
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-17.yaml
+++ b/v1/nightlies/nightly-2018-05-17.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-17:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      branch: master
-      tag: 2.5.0
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        branch: master
+        tag: 2.5.0
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-18.yaml
+++ b/v1/nightlies/nightly-2018-05-18.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-18:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: 4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: 4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-21.yaml
+++ b/v1/nightlies/nightly-2018-05-21.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-21:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: 4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 6.2.0
-      branch: master
-      ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: 4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 6.2.0
+        branch: master
+        ref: 28f96cac4b55ac0eaa4b32fdce3426d9aa912ea2
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-22.yaml
+++ b/v1/nightlies/nightly-2018-05-22.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-22:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: 4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: 4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-23.yaml
+++ b/v1/nightlies/nightly-2018-05-23.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-23:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: 4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: 4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-05-25.yaml
+++ b/v1/nightlies/nightly-2018-05-25.yaml
@@ -1,474 +1,479 @@
 ---
 releases:
   nightly-2018-05-25:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: 4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: 4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-05.yaml
+++ b/v1/nightlies/nightly-2018-06-05.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-05:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-06.yaml
+++ b/v1/nightlies/nightly-2018-06-06.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-06:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-07.yaml
+++ b/v1/nightlies/nightly-2018-06-07.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-07:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-08.yaml
+++ b/v1/nightlies/nightly-2018-06-08.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-08:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-11.yaml
+++ b/v1/nightlies/nightly-2018-06-11.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-11:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-12.yaml
+++ b/v1/nightlies/nightly-2018-06-12.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-12:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-13.yaml
+++ b/v1/nightlies/nightly-2018-06-13.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-13:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-14.yaml
+++ b/v1/nightlies/nightly-2018-06-14.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-14:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-15.yaml
+++ b/v1/nightlies/nightly-2018-06-15.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-15:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-18.yaml
+++ b/v1/nightlies/nightly-2018-06-18.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-18:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-19.yaml
+++ b/v1/nightlies/nightly-2018-06-19.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-19:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-20.yaml
+++ b/v1/nightlies/nightly-2018-06-20.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-20:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-21.yaml
+++ b/v1/nightlies/nightly-2018-06-21.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-21:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-22.yaml
+++ b/v1/nightlies/nightly-2018-06-22.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-22:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-25.yaml
+++ b/v1/nightlies/nightly-2018-06-25.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-25:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-26.yaml
+++ b/v1/nightlies/nightly-2018-06-26.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-26:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-27.yaml
+++ b/v1/nightlies/nightly-2018-06-27.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-27:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-28.yaml
+++ b/v1/nightlies/nightly-2018-06-28.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-28:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-06-29.yaml
+++ b/v1/nightlies/nightly-2018-06-29.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-06-29:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-02.yaml
+++ b/v1/nightlies/nightly-2018-07-02.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-02:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-03.yaml
+++ b/v1/nightlies/nightly-2018-07-03.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-03:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-04.yaml
+++ b/v1/nightlies/nightly-2018-07-04.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-04:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-05.yaml
+++ b/v1/nightlies/nightly-2018-07-05.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-05:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-06.yaml
+++ b/v1/nightlies/nightly-2018-07-06.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-06:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: 5e0912598c0dd578477c389d68db120fd09e6e29
-      branch: master
-      tag: 6.0.5
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: 5e0912598c0dd578477c389d68db120fd09e6e29
+        branch: master
+        tag: 6.0.5
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-09.yaml
+++ b/v1/nightlies/nightly-2018-07-09.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-09:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: 7e96b121de7fd3b7a02ae627fe3c678915b87cf0
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: 7e96b121de7fd3b7a02ae627fe3c678915b87cf0
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-10.yaml
+++ b/v1/nightlies/nightly-2018-07-10.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-10:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: 7e96b121de7fd3b7a02ae627fe3c678915b87cf0
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: 7e96b121de7fd3b7a02ae627fe3c678915b87cf0
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-11.yaml
+++ b/v1/nightlies/nightly-2018-07-11.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-11:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-12.yaml
+++ b/v1/nightlies/nightly-2018-07-12.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-12:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-13.yaml
+++ b/v1/nightlies/nightly-2018-07-13.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-13:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-16.yaml
+++ b/v1/nightlies/nightly-2018-07-16.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-16:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-17.yaml
+++ b/v1/nightlies/nightly-2018-07-17.yaml
@@ -1,475 +1,480 @@
 ---
 releases:
   nightly-2018-07-17:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-18.yaml
+++ b/v1/nightlies/nightly-2018-07-18.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-18:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: fce2e5fcb0583185a963d19af82bb378338f5e25
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 7e2e811b51b81c1464927734262a941c5fa01f0c
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: fce2e5fcb0583185a963d19af82bb378338f5e25
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c11dab517beb6c9dcdda97ada58c328b4d1336d0
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-19.yaml
+++ b/v1/nightlies/nightly-2018-07-19.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-19:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-20.yaml
+++ b/v1/nightlies/nightly-2018-07-20.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-20:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 0121ac60dde06c7c3014df0b1fd4feb040518bca
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-23.yaml
+++ b/v1/nightlies/nightly-2018-07-23.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-23:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-24.yaml
+++ b/v1/nightlies/nightly-2018-07-24.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-24:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-25.yaml
+++ b/v1/nightlies/nightly-2018-07-25.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-25:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-26.yaml
+++ b/v1/nightlies/nightly-2018-07-26.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-26:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-27.yaml
+++ b/v1/nightlies/nightly-2018-07-27.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-27:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-30.yaml
+++ b/v1/nightlies/nightly-2018-07-30.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-30:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-07-31.yaml
+++ b/v1/nightlies/nightly-2018-07-31.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-07-31:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
-      tag: 5.5.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: cd732173fb159217596118c7e0c0a98c6ca1b84d
+        tag: 5.5.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-01.yaml
+++ b/v1/nightlies/nightly-2018-08-01.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-01:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-02.yaml
+++ b/v1/nightlies/nightly-2018-08-02.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-02:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-03.yaml
+++ b/v1/nightlies/nightly-2018-08-03.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-03:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-06.yaml
+++ b/v1/nightlies/nightly-2018-08-06.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-06:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-07.yaml
+++ b/v1/nightlies/nightly-2018-08-07.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-07:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-08.yaml
+++ b/v1/nightlies/nightly-2018-08-08.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-08:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-09.yaml
+++ b/v1/nightlies/nightly-2018-08-09.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-09:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-10.yaml
+++ b/v1/nightlies/nightly-2018-08-10.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-10:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-13.yaml
+++ b/v1/nightlies/nightly-2018-08-13.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-13:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-14.yaml
+++ b/v1/nightlies/nightly-2018-08-14.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-14:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-15.yaml
+++ b/v1/nightlies/nightly-2018-08-15.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-15:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-16.yaml
+++ b/v1/nightlies/nightly-2018-08-16.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-16:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-17.yaml
+++ b/v1/nightlies/nightly-2018-08-17.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-17:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: dfb697710c4d3f9bdc1ab7d4a261b702beb33b95
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-20.yaml
+++ b/v1/nightlies/nightly-2018-08-20.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-20:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 476bd30f5542be8632481e7c31679f8bddce29ce
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 0b83b0e757d6a9078518b2e3934a69e82488e5ef
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 659af8469e66229e4a4a71e166514e70cbbdb1ae
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 476bd30f5542be8632481e7c31679f8bddce29ce
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: b95546b5c4d476836165a1e73cefd4d0c08a59ea
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-21.yaml
+++ b/v1/nightlies/nightly-2018-08-21.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-21:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 2807f326d957056bf6290f04c9cf0b550548c19d
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 2807f326d957056bf6290f04c9cf0b550548c19d
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-22.yaml
+++ b/v1/nightlies/nightly-2018-08-22.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-22:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: simp6.0.0-2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: simp6.0.0-4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: simp6.0.0-6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 2807f326d957056bf6290f04c9cf0b550548c19d
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: simp6.0.0-2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: simp6.0.0-4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: simp6.0.0-6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 2807f326d957056bf6290f04c9cf0b550548c19d
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-23.yaml
+++ b/v1/nightlies/nightly-2018-08-23.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-23:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 2807f326d957056bf6290f04c9cf0b550548c19d
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 2807f326d957056bf6290f04c9cf0b550548c19d
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-30.yaml
+++ b/v1/nightlies/nightly-2018-08-30.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-30:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 2807f326d957056bf6290f04c9cf0b550548c19d
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 2807f326d957056bf6290f04c9cf0b550548c19d
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-08-31.yaml
+++ b/v1/nightlies/nightly-2018-08-31.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-08-31:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 2807f326d957056bf6290f04c9cf0b550548c19d
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 2807f326d957056bf6290f04c9cf0b550548c19d
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-03.yaml
+++ b/v1/nightlies/nightly-2018-09-03.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-03:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 2807f326d957056bf6290f04c9cf0b550548c19d
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 2807f326d957056bf6290f04c9cf0b550548c19d
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-04.yaml
+++ b/v1/nightlies/nightly-2018-09-04.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-04:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 461e637cf6a73b971ed26757be639598369eb6ab
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 461e637cf6a73b971ed26757be639598369eb6ab
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-05.yaml
+++ b/v1/nightlies/nightly-2018-09-05.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-05:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 461e637cf6a73b971ed26757be639598369eb6ab
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
-      tag: 0.4.4
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 461e637cf6a73b971ed26757be639598369eb6ab
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 5020763a081cf2a6fff5fa49d05605e8c45efb0a
+        tag: 0.4.4
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-06.yaml
+++ b/v1/nightlies/nightly-2018-09-06.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-06:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 9983e9c593ac8ad71f782b292c2ba18bb29e0456
-      tag: 0.5.0
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 9983e9c593ac8ad71f782b292c2ba18bb29e0456
+        tag: 0.5.0
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-07.yaml
+++ b/v1/nightlies/nightly-2018-09-07.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-07:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 6645aabe6609f35d831ea572407a04a0348136be
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 7e502456bd927dd3d171996d09aecd43e526c271
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 373d658fb00eb827ceef35ddd3baac35f1227286
-      tag: 5.5.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 6645aabe6609f35d831ea572407a04a0348136be
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 7e502456bd927dd3d171996d09aecd43e526c271
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 373d658fb00eb827ceef35ddd3baac35f1227286
+        tag: 5.5.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-10.yaml
+++ b/v1/nightlies/nightly-2018-09-10.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-10:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 7e502456bd927dd3d171996d09aecd43e526c271
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 7e502456bd927dd3d171996d09aecd43e526c271
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-11.yaml
+++ b/v1/nightlies/nightly-2018-09-11.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-11:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 7e502456bd927dd3d171996d09aecd43e526c271
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 7e502456bd927dd3d171996d09aecd43e526c271
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-12.yaml
+++ b/v1/nightlies/nightly-2018-09-12.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-12:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-13.yaml
+++ b/v1/nightlies/nightly-2018-09-13.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-13:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-14.yaml
+++ b/v1/nightlies/nightly-2018-09-14.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-14:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-17.yaml
+++ b/v1/nightlies/nightly-2018-09-17.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-17:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-18.yaml
+++ b/v1/nightlies/nightly-2018-09-18.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-18:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-19.yaml
+++ b/v1/nightlies/nightly-2018-09-19.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-19:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-20.yaml
+++ b/v1/nightlies/nightly-2018-09-20.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-20:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
-      branch: master
-      tag: 3.0.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: simp6.0.0-1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: simp6.0.0-5.4.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: f2ab58c60fe4fa38166d3e55a125c3039db0a3de
+        branch: master
+        tag: 3.0.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: simp6.0.0-1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: simp6.0.0-5.4.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-21.yaml
+++ b/v1/nightlies/nightly-2018-09-21.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-21:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-24.yaml
+++ b/v1/nightlies/nightly-2018-09-24.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-24:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4e29459c00905f3f0b141731d7ceb24066ac56fe
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-25.yaml
+++ b/v1/nightlies/nightly-2018-09-25.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-25:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
-      tag: 5.5.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 8b288cc59325c6d5525f0b9ff0b305c6c1deae79
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: b6ca3d5fe00939fdf782820a8c572353dbe9c235
+        tag: 5.5.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-26.yaml
+++ b/v1/nightlies/nightly-2018-09-26.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-26:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: aa806acda444756762b2c4308e23e19a11c7a64d
-      tag: 5.6.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: aa806acda444756762b2c4308e23e19a11c7a64d
+        tag: 5.6.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-27.yaml
+++ b/v1/nightlies/nightly-2018-09-27.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-27:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: aa806acda444756762b2c4308e23e19a11c7a64d
-      tag: 5.6.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 909da12150ff6e32ee7c74021fdf0756cc9acb6d
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: aa806acda444756762b2c4308e23e19a11c7a64d
+        tag: 5.6.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-09-28.yaml
+++ b/v1/nightlies/nightly-2018-09-28.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-09-28:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: aa806acda444756762b2c4308e23e19a11c7a64d
-      tag: 5.6.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: 5212ae09a358843cd7838f1ac8842cd97b5f7628
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: aa806acda444756762b2c4308e23e19a11c7a64d
+        tag: 5.6.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-01.yaml
+++ b/v1/nightlies/nightly-2018-10-01.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-01:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: aa806acda444756762b2c4308e23e19a11c7a64d
-      tag: 5.6.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: aa806acda444756762b2c4308e23e19a11c7a64d
+        tag: 5.6.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-02.yaml
+++ b/v1/nightlies/nightly-2018-10-02.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-02:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: aa806acda444756762b2c4308e23e19a11c7a64d
-      tag: 5.6.0
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: aa806acda444756762b2c4308e23e19a11c7a64d
+        tag: 5.6.0
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-03.yaml
+++ b/v1/nightlies/nightly-2018-10-03.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-03:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-04.yaml
+++ b/v1/nightlies/nightly-2018-10-04.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-04:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-05.yaml
+++ b/v1/nightlies/nightly-2018-10-05.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-05:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-08.yaml
+++ b/v1/nightlies/nightly-2018-10-08.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-08:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-09.yaml
+++ b/v1/nightlies/nightly-2018-10-09.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-09:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-10.yaml
+++ b/v1/nightlies/nightly-2018-10-10.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-10:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-11.yaml
+++ b/v1/nightlies/nightly-2018-10-11.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-11:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-12.yaml
+++ b/v1/nightlies/nightly-2018-10-12.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-12:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-15.yaml
+++ b/v1/nightlies/nightly-2018-10-15.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-15:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
-      branch: master
-      tag: 3.1.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
-      branch: master
-      tag: 2.0.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
-      branch: master
-      tag: 5.9.0
-    puppetlabs-stdlib:
-      tag: 5.0.0
-      branch: master
-      ref: 72512b37b68f5e727d7c0050284c715c3cef299b
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: bf60d1327be47b9861bb9571f8403bcab29f43a8
+        branch: master
+        tag: 3.1.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 4482d1a4da76aa072e55e11392e00cc730de20ca
+        branch: master
+        tag: 2.0.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 2890aba6a835cc6a75804316db385fdbe8368fe6
+        branch: master
+        tag: 5.9.0
+      puppetlabs-stdlib:
+        tag: 5.0.0
+        branch: master
+        ref: 72512b37b68f5e727d7c0050284c715c3cef299b
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: fd05e3e4e2adcf6101e798672bc639627ef058f2
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-16.yaml
+++ b/v1/nightlies/nightly-2018-10-16.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-16:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-17.yaml
+++ b/v1/nightlies/nightly-2018-10-17.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-17:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-18.yaml
+++ b/v1/nightlies/nightly-2018-10-18.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-18:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-19.yaml
+++ b/v1/nightlies/nightly-2018-10-19.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-19:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-22.yaml
+++ b/v1/nightlies/nightly-2018-10-22.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-22:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-23.yaml
+++ b/v1/nightlies/nightly-2018-10-23.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-23:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-24.yaml
+++ b/v1/nightlies/nightly-2018-10-24.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-24:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-25.yaml
+++ b/v1/nightlies/nightly-2018-10-25.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-25:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-26.yaml
+++ b/v1/nightlies/nightly-2018-10-26.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-26:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
-      tag: 5.6.1
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 0a2b3342e9713b4fc9b5736cc1c42be59ff95095
+        tag: 5.6.1
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-29.yaml
+++ b/v1/nightlies/nightly-2018-10-29.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-29:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-30.yaml
+++ b/v1/nightlies/nightly-2018-10-30.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-30:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-10-31.yaml
+++ b/v1/nightlies/nightly-2018-10-31.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-10-31:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-01.yaml
+++ b/v1/nightlies/nightly-2018-11-01.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-01:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-02.yaml
+++ b/v1/nightlies/nightly-2018-11-02.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-02:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-05.yaml
+++ b/v1/nightlies/nightly-2018-11-05.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-05:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
-      branch: master
-      tag: 8.0.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 6a60e860b2e2f28312e323abe16c754d71a02cab
+        branch: master
+        tag: 8.0.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-06.yaml
+++ b/v1/nightlies/nightly-2018-11-06.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-06:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-07.yaml
+++ b/v1/nightlies/nightly-2018-11-07.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-07:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
-      tag: 5.6.2
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: 82928783e7df23fd5b5a47fcf7f8200d5dd49eff
+        tag: 5.6.2
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-08.yaml
+++ b/v1/nightlies/nightly-2018-11-08.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-08:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-09.yaml
+++ b/v1/nightlies/nightly-2018-11-09.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-09:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-12.yaml
+++ b/v1/nightlies/nightly-2018-11-12.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-12:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: bc06153c329bf8a75be134f5b27d68421b82004e
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: cee26996deed765d44d9c643af1282151e2a41d7
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: '0000000000000000000000000000000000000000'
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: bc06153c329bf8a75be134f5b27d68421b82004e
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 57e9ef19d2a2b0945c7d73122600f976c43a27bd
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: fbae038548c7b76aa50d0cc4285b1d3c5ed4800d
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: a2c5d5faee91e901bce1662da297b6b893ad32dc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: b70d788f315bc1055d207b45e53a02cb1bca8be6
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 5a8b753704917bb94ade6b5194c975b541b5cb38
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 8c7c08cfeb26546709c89023bdab3a296ed38a83
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: cc7018ac472ffdb6f4865a26542a29a98709b89c
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: cee26996deed765d44d9c643af1282151e2a41d7
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: '0000000000000000000000000000000000000000'
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-13.yaml
+++ b/v1/nightlies/nightly-2018-11-13.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-13:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-14.yaml
+++ b/v1/nightlies/nightly-2018-11-14.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-14:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 58c124c131cb8f81f15cfd23cb3be2ce2cb5cc6e
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-15.yaml
+++ b/v1/nightlies/nightly-2018-11-15.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-15:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-16.yaml
+++ b/v1/nightlies/nightly-2018-11-16.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-16:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: beaefcbf0badf654fc0d74520734db08ae79e74d
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 832a8a5d6f81677b6329c4d7898b17d937532929
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
-      branch: master
-      tag: 8.1.0
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: beaefcbf0badf654fc0d74520734db08ae79e74d
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 832a8a5d6f81677b6329c4d7898b17d937532929
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 114a9c167b1ddcc424e17f45a3874382c8198feb
+        branch: master
+        tag: 8.1.0
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 9fd0cfe68b6b8785f4f149ef1c7f6a5cb558be14
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 2cad06e1b8b5f2560bb92c44832a13dd0feeef04
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-19.yaml
+++ b/v1/nightlies/nightly-2018-11-19.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-19:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-20.yaml
+++ b/v1/nightlies/nightly-2018-11-20.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-20:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-21.yaml
+++ b/v1/nightlies/nightly-2018-11-21.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-21:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-22.yaml
+++ b/v1/nightlies/nightly-2018-11-22.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-22:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-23.yaml
+++ b/v1/nightlies/nightly-2018-11-23.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-23:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-26.yaml
+++ b/v1/nightlies/nightly-2018-11-26.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-26:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-27.yaml
+++ b/v1/nightlies/nightly-2018-11-27.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-27:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-28.yaml
+++ b/v1/nightlies/nightly-2018-11-28.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-28:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-29.yaml
+++ b/v1/nightlies/nightly-2018-11-29.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-29:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-11-30.yaml
+++ b/v1/nightlies/nightly-2018-11-30.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-11-30:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-12-03.yaml
+++ b/v1/nightlies/nightly-2018-12-03.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-12-03:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-12-04.yaml
+++ b/v1/nightlies/nightly-2018-12-04.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-12-04:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/nightlies/nightly-2018-12-05.yaml
+++ b/v1/nightlies/nightly-2018-12-05.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   nightly-2018-12-05:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/packages.yaml
+++ b/v1/packages.yaml
@@ -1,0 +1,176 @@
+---
+packages:
+  apr-util-ldap:
+    type: package
+  chkrootkit:
+    type: package
+  clamav:
+    type: package
+  clamav-data:
+    type: package
+  clamav-devel:
+    type: package
+  clamav-filesystem:
+    type: package
+  clamav-lib:
+    type: package
+  clamav-scanner-systemd:
+    type: package
+  clamav-server-systemd:
+    type: package
+  clamav-update:
+    type: package
+  clamd:
+    type: package
+  elasticsearch:
+    type: package
+  elasticsearch-curator:
+    type: package
+  grafana:
+    type: package
+  gweb:
+    type: package
+  haveged:
+    type: package
+  incron:
+    type: package
+  libarchive-devel:
+    type: package
+  libconfuse:
+    type: package
+  libev:
+    type: package
+  logstash:
+    type: package
+  pdsh:
+    type: package
+  pdsh-debuginfo:
+    type: package
+  pdsh-mod-dshgroup:
+    type: package
+  pdsh-mod-machines:
+    type: package
+  pdsh-mod-netgroup:
+    type: package
+  pdsh-rcmd-exec:
+    type: package
+  pdsh-rcmd-ssh:
+    type: package
+  postgresql96:
+    type: package
+  postgresql96-contrib:
+    type: package
+  postgresql96-libs:
+    type: package
+  postgresql96-server:
+    type: package
+  pssh:
+    type: package
+  puppet-agent:
+    type: package
+  puppet-client-tools:
+    type: package
+  puppetdb:
+    type: package
+  puppetdb-termini:
+    type: package
+  puppetlabs-release-pc1:
+    type: package
+  puppetserver:
+    type: package
+  python-linecache2:
+    type: package
+  python-redis:
+    type: package
+  python-simplejson:
+    type: package
+  python-traceback2:
+    type: package
+  python-unittest2:
+    type: package
+  ruby-augeas:
+    type: package
+  ruby-ldap:
+    type: package
+  ruby-rgen:
+    type: package
+  ruby-shadow:
+    type: package
+  rubygem-deep_merge:
+    type: package
+  rubygem-ffi:
+    type: package
+  rubygem-highline:
+    type: package
+  rubygem-net-ldap:
+    type: package
+  rubygem-net-ldap-doc:
+    type: package
+  rubygem-net-ping:
+    type: package
+  rubygem-puppet-lint:
+    type: package
+  rubygem-puppetserver-blankslate:
+    type: package
+  rubygem-puppetserver-blankslate-doc:
+    type: package
+  rubygem-puppetserver-parslet:
+    type: package
+  rubygem-puppetserver-parslet-doc:
+    type: package
+  rubygem-puppetserver-toml:
+    type: package
+  rubygem-puppetserver-toml-doc:
+    type: package
+  rubygem-rake:
+    type: package
+  rubygem-rake-compiler:
+    type: package
+  rubygem-stomp:
+    type: package
+  rubygem-stomp-doc:
+    type: package
+  simp-lastbind:
+    type: package
+  simp-ppolicy-check-password:
+    type: package
+  simp-vendored-r10k:
+    type: package
+  simp-vendored-r10k-doc:
+    type: package
+  simp-vendored-r10k-gem-colored:
+    type: package
+  simp-vendored-r10k-gem-cri:
+    type: package
+  simp-vendored-r10k-gem-faraday:
+    type: package
+  simp-vendored-r10k-gem-faraday_middleware:
+    type: package
+  simp-vendored-r10k-gem-fast_gettext:
+    type: package
+  simp-vendored-r10k-gem-gettext:
+    type: package
+  simp-vendored-r10k-gem-gettext-setup:
+    type: package
+  simp-vendored-r10k-gem-locale:
+    type: package
+  simp-vendored-r10k-gem-log4r:
+    type: package
+  simp-vendored-r10k-gem-minitar:
+    type: package
+  simp-vendored-r10k-gem-multi_json:
+    type: package
+  simp-vendored-r10k-gem-multipart-post:
+    type: package
+  simp-vendored-r10k-gem-puppet_forge:
+    type: package
+  simp-vendored-r10k-gem-r10k:
+    type: package
+  simp-vendored-r10k-gem-semantic_puppet:
+    type: package
+  simp-vendored-r10k-gem-text:
+    type: package
+  sudosh2:
+    type: package
+  syslinux-tftpboot:
+    type: package

--- a/v1/packages/CentOS/6/6.2.0-0.yaml
+++ b/v1/packages/CentOS/6/6.2.0-0.yaml
@@ -1,0 +1,340 @@
+---
+releases:
+  6.2.0-0:
+    packages:
+      apr-util-ldap:
+        :rpm_name: apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
+        :source: http://mirror.centos.org/centos/6/os/x86_64/Packages/apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
+      chkrootkit:
+        :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
+        :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/Packages/c/chkrootkit-0.49-9.el6.x86_64.rpm
+      clamav:
+        :rpm_name: clamav-0.100.1-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-0.100.1-2.el6.x86_64.rpm
+      clamav-db:
+        :rpm_name: clamav-db-0.100.1-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-db-0.100.1-2.el6.x86_64.rpm
+      clamav-devel:
+        :rpm_name: clamav-devel-0.100.1-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-devel-0.100.1-2.el6.x86_64.rpm
+      clamav-milter:
+        :rpm_name: clamav-milter-0.100.1-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-milter-0.100.1-2.el6.x86_64.rpm
+      clamav-unofficial-sigs:
+        :rpm_name: clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
+      clamd:
+        :rpm_name: clamd-0.100.1-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamd-0.100.1-2.el6.x86_64.rpm
+      clamsmtp:
+        :rpm_name: clamsmtp-1.10-7.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamsmtp-1.10-7.el6.x86_64.rpm
+      elasticsearch:
+        :rpm_name: elasticsearch-5.6.10.rpm
+        :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm
+      elasticsearch-curator:
+        :rpm_name: elasticsearch-curator-5.5.4-1.x86_64.rpm
+        :source: http://packages.elastic.co/curator/5/centos/6/Packages/elasticsearch-curator-5.5.4-1.x86_64.rpm
+      fping:
+        :rpm_name: fping-2.4b2-10.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/f/fping-2.4b2-10.el6.x86_64.rpm
+      ganglia:
+        :rpm_name: ganglia-3.7.2-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-3.7.2-2.el6.x86_64.rpm
+      ganglia-devel:
+        :rpm_name: ganglia-devel-3.7.2-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-devel-3.7.2-2.el6.x86_64.rpm
+      ganglia-gmetad:
+        :rpm_name: ganglia-gmetad-3.7.2-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-gmetad-3.7.2-2.el6.x86_64.rpm
+      ganglia-gmond:
+        :rpm_name: ganglia-gmond-3.7.2-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-gmond-3.7.2-2.el6.x86_64.rpm
+      ganglia-gmond-python:
+        :rpm_name: ganglia-gmond-python-3.7.2-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-gmond-python-3.7.2-2.el6.x86_64.rpm
+      globus-callout:
+        :rpm_name: globus-callout-3.15-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-callout-3.15-1.el6.x86_64.rpm
+      globus-common:
+        :rpm_name: globus-common-17.4-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-common-17.4-1.el6.x86_64.rpm
+      globus-gsi-callback:
+        :rpm_name: globus-gsi-callback-5.13-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-callback-5.13-1.el6.x86_64.rpm
+      globus-gsi-cert-utils:
+        :rpm_name: globus-gsi-cert-utils-9.16-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-cert-utils-9.16-1.el6.x86_64.rpm
+      globus-gsi-credential:
+        :rpm_name: globus-gsi-credential-7.14-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-credential-7.14-1.el6.x86_64.rpm
+      globus-gsi-openssl-error:
+        :rpm_name: globus-gsi-openssl-error-3.8-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-openssl-error-3.8-1.el6.x86_64.rpm
+      globus-gsi-proxy-core:
+        :rpm_name: globus-gsi-proxy-core-8.6-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-proxy-core-8.6-1.el6.x86_64.rpm
+      globus-gsi-proxy-ssl:
+        :rpm_name: globus-gsi-proxy-ssl-5.10-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-proxy-ssl-5.10-1.el6.x86_64.rpm
+      globus-gsi-sysconfig:
+        :rpm_name: globus-gsi-sysconfig-8.1-3.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-sysconfig-8.1-3.el6.x86_64.rpm
+      globus-gss-assist:
+        :rpm_name: globus-gss-assist-11.2-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gss-assist-11.2-1.el6.x86_64.rpm
+      globus-gssapi-gsi:
+        :rpm_name: globus-gssapi-gsi-13.10-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gssapi-gsi-13.10-1.el6.x86_64.rpm
+      globus-openssl-module:
+        :rpm_name: globus-openssl-module-4.8-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-openssl-module-4.8-1.el6.x86_64.rpm
+      grafana:
+        :rpm_name: grafana-4.6.3-1.x86_64.rpm
+        :source: https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.6.3-1.x86_64.rpm
+      gweb:
+        :rpm_name: gweb-2.1.8-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/gweb-2.1.8-1.noarch.rpm
+      haveged:
+        :rpm_name: haveged-1.9.1-2.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/h/haveged-1.9.1-2.el6.x86_64.rpm
+      incron:
+        :rpm_name: incron-0.5.9-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/i/incron-0.5.9-1.el6.x86_64.rpm
+      lcgdm-libs:
+        :rpm_name: lcgdm-libs-1.10.0-5.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/lcgdm-libs-1.10.0-5.el6.x86_64.rpm
+      leiningen:
+        :rpm_name: leiningen-2.0.0-0.2preview10.el6.noarch.rpm
+        :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/leiningen-2.0.0-0.2preview10.el6.noarch.rpm
+      lfc-libs:
+        :rpm_name: lfc-libs-1.10.0-5.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/lfc-libs-1.10.0-5.el6.x86_64.rpm
+      lfc-python:
+        :rpm_name: lfc-python-1.10.0-5.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/lfc-python-1.10.0-5.el6.x86_64.rpm
+      libconfuse:
+        :rpm_name: libconfuse-2.7-4.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libconfuse-2.7-4.el6.x86_64.rpm
+      libev:
+        :rpm_name: libev-4.03-3.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libev-4.03-3.el6.x86_64.rpm
+      libyaml:
+        :rpm_name: libyaml-0.1.4-2.el6.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-0.1.4-2.el6.x86_64.rpm
+      libyaml-devel:
+        :rpm_name: libyaml-devel-0.1.4-2.el6.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-devel-0.1.4-2.el6.x86_64.rpm
+      logstash:
+        :rpm_name: logstash-5.6.10.rpm
+        :source: https://artifacts.elastic.co/downloads/logstash/logstash-5.6.10.rpm
+      mrepo:
+        :rpm_name: mrepo-0.8.7-2.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/m/mrepo-0.8.7-2.el6.noarch.rpm
+      mysql-connector-python:
+        :rpm_name: mysql-connector-python-1.1.6-1.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/m/mysql-connector-python-1.1.6-1.el6.noarch.rpm
+      pdsh:
+        :rpm_name: pdsh-2.28-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-2.28-0.x86_64.rpm
+      pdsh-mod-dshgroup:
+        :rpm_name: pdsh-mod-dshgroup-2.28-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
+      pdsh-mod-machines:
+        :rpm_name: pdsh-mod-machines-2.28-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-machines-2.28-0.x86_64.rpm
+      pdsh-mod-netgroup:
+        :rpm_name: pdsh-mod-netgroup-2.28-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-netgroup-2.28-0.x86_64.rpm
+      pdsh-rcmd-exec:
+        :rpm_name: pdsh-rcmd-exec-2.28-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-exec-2.28-0.x86_64.rpm
+      pdsh-rcmd-ssh:
+        :rpm_name: pdsh-rcmd-ssh-2.28-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
+      perl-Crypt-DES:
+        :rpm_name: perl-Crypt-DES-2.05-9.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Crypt-DES-2.05-9.el6.x86_64.rpm
+      perl-File-RsyncP:
+        :rpm_name: perl-File-RsyncP-0.72-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-File-RsyncP-0.72-1.el6.x86_64.rpm
+      perl-Math-Calc-Units:
+        :rpm_name: perl-Math-Calc-Units-1.07-6.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Math-Calc-Units-1.07-6.el6.noarch.rpm
+      perl-Net-FTP-AutoReconnect:
+        :rpm_name: perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch.rpm
+      perl-Net-FTP-RetrHandle:
+        :rpm_name: perl-Net-FTP-RetrHandle-0.2-3.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Net-FTP-RetrHandle-0.2-3.el6.noarch.rpm
+      perl-Net-SNMP:
+        :rpm_name: perl-Net-SNMP-5.2.0-4.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Net-SNMP-5.2.0-4.el6.noarch.rpm
+      perl-Sort-Versions:
+        :rpm_name: perl-Sort-Versions-1.5-12.el6.noarch.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Sort-Versions-1.5-12.el6.noarch.rpm
+      perl-Time-modules:
+        :rpm_name: perl-Time-modules-2006.0814-5.el6.noarch.rpm
+        :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/perl-Time-modules-2006.0814-5.el6.noarch.rpm
+      postgresql96:
+        :rpm_name: postgresql96-9.6.9-1PGDG.rhel6.x86_64.rpm
+        :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-9.6.9-1PGDG.rhel6.x86_64.rpm
+      postgresql96-contrib:
+        :rpm_name: postgresql96-contrib-9.6.9-1PGDG.rhel6.x86_64.rpm
+        :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-contrib-9.6.9-1PGDG.rhel6.x86_64.rpm
+      postgresql96-libs:
+        :rpm_name: postgresql96-libs-9.6.9-1PGDG.rhel6.x86_64.rpm
+        :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-libs-9.6.9-1PGDG.rhel6.x86_64.rpm
+      postgresql96-server:
+        :rpm_name: postgresql96-server-9.6.9-1PGDG.rhel6.x86_64.rpm
+        :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-server-9.6.9-1PGDG.rhel6.x86_64.rpm
+      pssh:
+        :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pssh-2.3.1-5.el6.noarch.rpm
+      puppet-agent:
+        :rpm_name: puppet-agent-1.10.14-1.el6.x86_64.rpm
+        :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.14-1.el6.x86_64.rpm
+      puppet-client-tools:
+        :rpm_name: puppet-client-tools-1.2.1-1.el6.x86_64.rpm
+        :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-client-tools-1.2.1-1.el6.x86_64.rpm
+      puppetdb:
+        :rpm_name: puppetdb-4.4.0-1.el6.noarch.rpm
+        :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/puppetdb-4.4.0-1.el6.noarch.rpm
+      puppetdb-termini:
+        :rpm_name: puppetdb-termini-4.4.0-1.el6.noarch.rpm
+        :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppetdb-termini-4.4.0-1.el6.noarch.rpm
+      puppetlabs-release-pc1:
+        :rpm_name: puppetlabs-release-pc1-1.1.0-5.el6.noarch.rpm
+        :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppetlabs-release-pc1-1.1.0-5.el6.noarch.rpm
+      puppetserver:
+        :rpm_name: puppetserver-2.8.1-1.el6.noarch.rpm
+        :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/puppetserver-2.8.1-1.el6.noarch.rpm
+      python-argparse:
+        :rpm_name: python-argparse-1.2.1-2.1.el6.noarch.rpm
+        :source: http://mirror.cogentco.com/pub/linux/centos/6/os/x86_64/Packages/python-argparse-1.2.1-2.1.el6.noarch.rpm
+      python-redis:
+        :rpm_name: python-redis-2.0.0-1.el6.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-redis-2.0.0-1.el6.noarch.rpm
+      python-unittest2:
+        :rpm_name: python-unittest2-0.5.1-3.el6.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-unittest2-0.5.1-3.el6.noarch.rpm
+      qstat:
+        :rpm_name: qstat-2.11-9.20080912svn311.el6.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/qstat-2.11-9.20080912svn311.el6.x86_64.rpm
+      radiusclient-ng:
+        :rpm_name: radiusclient-ng-0.5.6-5.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/r/radiusclient-ng-0.5.6-5.el6.x86_64.rpm
+      rlwrap:
+        :rpm_name: rlwrap-0.42-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/r/rlwrap-0.42-1.el6.x86_64.rpm
+      rubygem-ffi:
+        :rpm_name: rubygem-ffi-1.4.0-2.el6.x86_64.rpm
+        :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-ffi-1.4.0-2.el6.x86_64.rpm
+      rubygem-highline:
+        :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
+      rubygem-net-ldap:
+        :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
+      rubygem-net-ldap-doc:
+        :rpm_name: rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
+      rubygem-net-ping:
+        :rpm_name: rubygem-net-ping-1.6.2-1.el6.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
+      rubygem-puppetserver-blankslate:
+        :rpm_name: rubygem-puppetserver-blankslate-2.1.2.4-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-blankslate-2.1.2.4-1.noarch.rpm
+      rubygem-puppetserver-blankslate-doc:
+        :rpm_name: rubygem-puppetserver-blankslate-doc-2.1.2.4-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-blankslate-doc-2.1.2.4-1.noarch.rpm
+      rubygem-puppetserver-parslet:
+        :rpm_name: rubygem-puppetserver-parslet-1.5.0-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.5.0-1.noarch.rpm
+      rubygem-puppetserver-parslet-doc:
+        :rpm_name: rubygem-puppetserver-parslet-doc-1.5.0-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-doc-1.5.0-1.noarch.rpm
+      rubygem-puppetserver-toml:
+        :rpm_name: rubygem-puppetserver-toml-0.1.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.1.2-1.noarch.rpm
+      rubygem-puppetserver-toml-doc:
+        :rpm_name: rubygem-puppetserver-toml-doc-0.1.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-doc-0.1.2-1.noarch.rpm
+      rubygem-rake-compiler:
+        :rpm_name: rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
+        :source: http://http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
+      rubygem-stomp:
+        :rpm_name: rubygem-stomp-1.3.2-1.el6.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-1.3.2-1.el6.noarch.rpm
+      rubygem-stomp-doc:
+        :rpm_name: rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
+      simp-lastbind:
+        :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-lastbind-2.4.23-0.x86_64.rpm
+      simp-ppolicy-check-password:
+        :rpm_name: simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
+      simp-vendored-r10k:
+        :rpm_name: simp-vendored-r10k-2.6.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-2.6.2-1.noarch.rpm
+      simp-vendored-r10k-doc:
+        :rpm_name: simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
+      simp-vendored-r10k-gem-colored:
+        :rpm_name: simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
+      simp-vendored-r10k-gem-cri:
+        :rpm_name: simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
+      simp-vendored-r10k-gem-faraday:
+        :rpm_name: simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
+      simp-vendored-r10k-gem-faraday_middleware:
+        :rpm_name: simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
+      simp-vendored-r10k-gem-fast_gettext:
+        :rpm_name: simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
+      simp-vendored-r10k-gem-gettext:
+        :rpm_name: simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
+      simp-vendored-r10k-gem-gettext-setup:
+        :rpm_name: simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
+      simp-vendored-r10k-gem-locale:
+        :rpm_name: simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
+      simp-vendored-r10k-gem-log4r:
+        :rpm_name: simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
+      simp-vendored-r10k-gem-minitar:
+        :rpm_name: simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
+      simp-vendored-r10k-gem-multi_json:
+        :rpm_name: simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
+      simp-vendored-r10k-gem-multipart-post:
+        :rpm_name: simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
+      simp-vendored-r10k-gem-puppet_forge:
+        :rpm_name: simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
+      simp-vendored-r10k-gem-r10k:
+        :rpm_name: simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
+      simp-vendored-r10k-gem-semantic_puppet:
+        :rpm_name: simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
+      simp-vendored-r10k-gem-text:
+        :rpm_name: simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
+        :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
+      sudosh2:
+        :rpm_name: sudosh2-1.0.2-2.el6.x86_64.rpm
+        :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/sudosh2-1.0.2-2.el6.x86_64.rpm
+      tpm-tools-pkcs11:
+        :rpm_name: tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
+        :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
+      voms:
+        :rpm_name: voms-2.0.14-1.el6.x86_64.rpm
+        :source: http://lug.mtu.edu/epel/6/x86_64/Packages/v/voms-2.0.14-1.el6.x86_64.rpm

--- a/v1/packages/CentOS/7/6.2.0-0.yaml
+++ b/v1/packages/CentOS/7/6.2.0-0.yaml
@@ -1,0 +1,265 @@
+---
+releases:
+  6.2.0-0:
+    packages:
+      apr-util-ldap:
+        rpm_name: apr-util-ldap-1.5.2-6.el7.x86_64.rpm
+        source: http://vault.centos.org/7.4.1708/os/x86_64/Packages/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
+      chkrootkit:
+        rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
+      clamav:
+        rpm_name: clamav-0.100.1-3.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-3.el7.x86_64.rpm
+      clamav-data:
+        rpm_name: clamav-data-0.100.1-3.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-3.el7.noarch.rpm
+      clamav-devel:
+        rpm_name: clamav-devel-0.100.1-3.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-3.el7.x86_64.rpm
+      clamav-filesystem:
+        rpm_name: clamav-filesystem-0.100.1-3.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-3.el7.noarch.rpm
+      clamav-lib:
+        rpm_name: clamav-lib-0.100.1-3.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-3.el7.x86_64.rpm
+      clamav-scanner-systemd:
+        rpm_name: clamav-scanner-systemd-0.100.1-3.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-3.el7.x86_64.rpm
+      clamav-server-systemd:
+        rpm_name: clamav-server-systemd-0.100.1-3.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-3.el7.x86_64.rpm
+      clamav-update:
+        rpm_name: clamav-update-0.100.1-3.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-3.el7.x86_64.rpm
+      clamd:
+        rpm_name: clamd-0.100.1-3.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-3.el7.x86_64.rpm
+      elasticsearch:
+        rpm_name: elasticsearch-5.6.10.rpm
+        source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm
+      elasticsearch-curator:
+        rpm_name: elasticsearch-curator-5.5.4-1.x86_64.rpm
+        source: https://packages.elastic.co/curator/5/centos/7/Packages/elasticsearch-curator-5.5.4-1.x86_64.rpm
+      grafana:
+        rpm_name: grafana-4.6.3-1.x86_64.rpm
+        source: https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.6.3-1.x86_64.rpm
+      gweb:
+        rpm_name: gweb-2.1.8-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/gweb-2.1.8-1.noarch.rpm
+      haveged:
+        rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/h/haveged-1.9.1-1.el7.x86_64.rpm
+      incron:
+        rpm_name: incron-0.5.10-8.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/i/incron-0.5.10-8.el7.x86_64.rpm
+      libarchive-devel:
+        rpm_name: libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
+        source: http://mirror.steadfast.net/centos/7.4.1708/os/x86_64/Packages/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
+      libconfuse:
+        rpm_name: libconfuse-2.7-7.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libconfuse-2.7-7.el7.x86_64.rpm
+      libev:
+        rpm_name: libev-4.15-3.el7.x86_64.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libev-4.15-3.el7.x86_64.rpm
+      logstash:
+        rpm_name: logstash-5.6.10.rpm
+        source: https://artifacts.elastic.co/downloads/logstash/logstash-5.6.10.rpm
+      pdsh:
+        rpm_name: pdsh-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-2.29-1el7.x86_64.rpm
+      pdsh-debuginfo:
+        rpm_name: pdsh-debuginfo-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-debuginfo-2.29-1el7.x86_64.rpm
+      pdsh-mod-dshgroup:
+        rpm_name: pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
+      pdsh-mod-machines:
+        rpm_name: pdsh-mod-machines-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-machines-2.29-1el7.x86_64.rpm
+      pdsh-mod-netgroup:
+        rpm_name: pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
+      pdsh-rcmd-exec:
+        rpm_name: pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
+      pdsh-rcmd-ssh:
+        rpm_name: pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
+      postgresql96:
+        rpm_name: postgresql96-9.6.9-1PGDG.rhel7.x86_64.rpm
+        source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.9-1PGDG.rhel7.x86_64.rpm
+      postgresql96-contrib:
+        rpm_name: postgresql96-contrib-9.6.9-1PGDG.rhel7.x86_64.rpm
+        source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-contrib-9.6.9-1PGDG.rhel7.x86_64.rpm
+      postgresql96-libs:
+        rpm_name: postgresql96-libs-9.6.9-1PGDG.rhel7.x86_64.rpm
+        source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.9-1PGDG.rhel7.x86_64.rpm
+      postgresql96-server:
+        rpm_name: postgresql96-server-9.6.9-1PGDG.rhel7.x86_64.rpm
+        source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.9-1PGDG.rhel7.x86_64.rpm
+      pssh:
+        rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
+      puppet-agent:
+        rpm_name: puppet-agent-1.10.14-1.el7.x86_64.rpm
+        source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.14-1.el7.x86_64.rpm
+      puppet-client-tools:
+        rpm_name: puppet-client-tools-1.2.1-1.el7.x86_64.rpm
+        source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-client-tools-1.2.1-1.el7.x86_64.rpm
+      puppetdb:
+        rpm_name: puppetdb-4.4.0-1.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-4.4.0-1.el7.noarch.rpm
+      puppetdb-termini:
+        rpm_name: puppetdb-termini-4.4.0-1.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-termini-4.4.0-1.el7.noarch.rpm
+      puppetlabs-release-pc1:
+        rpm_name: puppetlabs-release-pc1-1.1.0-5.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetlabs-release-pc1-1.1.0-5.el7.noarch.rpm
+      puppetserver:
+        rpm_name: puppetserver-2.8.1-1.el7.noarch.rpm
+        source: https://yum.puppetlabs.com/el/7/PC1/x86_64/puppetserver-2.8.1-1.el7.noarch.rpm
+      python-linecache2:
+        rpm_name: python-linecache2-1.0.0-1.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-linecache2-1.0.0-1.el7.noarch.rpm
+      python-redis:
+        rpm_name: python-redis-2.10.3-1.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-redis-2.10.3-1.el7.noarch.rpm
+      python-simplejson:
+        rpm_name: python-simplejson-3.3.3-1.el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-simplejson-3.3.3-1.el7.x86_64.rpm
+      python-traceback2:
+        rpm_name: python-traceback2-1.4.0-2.el7.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-traceback2-1.4.0-2.el7.noarch.rpm
+      python-unittest2:
+        rpm_name: python-unittest2-1.1.0-4.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-unittest2-1.1.0-4.el7.noarch.rpm
+      ruby-augeas:
+        rpm_name: ruby-augeas-0.4.1-3.el7.x86_64.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
+      ruby-ldap:
+        rpm_name: ruby-ldap-0.9.16-1.el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/ruby-ldap-0.9.16-1.el7.x86_64.rpm
+      ruby-rgen:
+        rpm_name: ruby-rgen-0.6.5-2.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
+      ruby-shadow:
+        rpm_name: ruby-shadow-2.2.0-2.el7.x86_64.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-shadow-2.2.0-2.el7.x86_64.rpm
+      rubygem-deep_merge:
+        rpm_name: rubygem-deep_merge-1.0.0-2.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-deep_merge-1.0.0-2.el7.noarch.rpm
+      rubygem-ffi:
+        rpm_name: rubygem-ffi-1.4.0-2.el7.x86_64.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-ffi-1.4.0-2.el7.x86_64.rpm
+      rubygem-highline:
+        rpm_name: rubygem-highline-1.6.11-5.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-highline-1.6.11-5.el7.noarch.rpm
+      rubygem-net-ldap:
+        rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
+        source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
+      rubygem-net-ldap-doc:
+        rpm_name: rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
+        source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
+      rubygem-net-ping:
+        rpm_name: rubygem-net-ping-1.6.2-1.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-net-ping-1.6.2-1.el7.noarch.rpm
+      rubygem-puppet-lint:
+        rpm_name: rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
+        source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
+      rubygem-puppetserver-blankslate:
+        rpm_name: rubygem-puppetserver-blankslate-2.1.2.4-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-blankslate-2.1.2.4-1.noarch.rpm
+      rubygem-puppetserver-blankslate-doc:
+        rpm_name: rubygem-puppetserver-blankslate-doc-2.1.2.4-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-blankslate-doc-2.1.2.4-1.noarch.rpm
+      rubygem-puppetserver-parslet:
+        rpm_name: rubygem-puppetserver-parslet-1.5.0-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.5.0-1.noarch.rpm
+      rubygem-puppetserver-parslet-doc:
+        rpm_name: rubygem-puppetserver-parslet-doc-1.5.0-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-doc-1.5.0-1.noarch.rpm
+      rubygem-puppetserver-toml:
+        rpm_name: rubygem-puppetserver-toml-0.1.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.1.2-1.noarch.rpm
+      rubygem-puppetserver-toml-doc:
+        rpm_name: rubygem-puppetserver-toml-doc-0.1.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-doc-0.1.2-1.noarch.rpm
+      rubygem-rake:
+        rpm_name: rubygem-rake-0.9.6-33.el7_4.noarch.rpm
+        source: http://mirror.centos.org/centos/7/os/x86_64/Packages/rubygem-rake-0.9.6-33.el7_4.noarch.rpm
+      rubygem-rake-compiler:
+        rpm_name: rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
+        source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
+      rubygem-stomp:
+        rpm_name: rubygem-stomp-1.3.5-1.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-1.3.5-1.el7.noarch.rpm
+      rubygem-stomp-doc:
+        rpm_name: rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
+        source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
+      simp-lastbind:
+        rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-lastbind-2.4.23-0.x86_64.rpm
+      simp-ppolicy-check-password:
+        rpm_name: simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
+      simp-vendored-r10k:
+        rpm_name: simp-vendored-r10k-2.6.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-2.6.2-1.noarch.rpm
+      simp-vendored-r10k-doc:
+        rpm_name: simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
+      simp-vendored-r10k-gem-colored:
+        rpm_name: simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
+      simp-vendored-r10k-gem-cri:
+        rpm_name: simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
+      simp-vendored-r10k-gem-faraday:
+        rpm_name: simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
+      simp-vendored-r10k-gem-faraday_middleware:
+        rpm_name: simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
+      simp-vendored-r10k-gem-fast_gettext:
+        rpm_name: simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
+      simp-vendored-r10k-gem-gettext:
+        rpm_name: simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
+      simp-vendored-r10k-gem-gettext-setup:
+        rpm_name: simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
+      simp-vendored-r10k-gem-locale:
+        rpm_name: simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
+      simp-vendored-r10k-gem-log4r:
+        rpm_name: simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
+      simp-vendored-r10k-gem-minitar:
+        rpm_name: simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
+      simp-vendored-r10k-gem-multi_json:
+        rpm_name: simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
+      simp-vendored-r10k-gem-multipart-post:
+        rpm_name: simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
+      simp-vendored-r10k-gem-puppet_forge:
+        rpm_name: simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
+      simp-vendored-r10k-gem-r10k:
+        rpm_name: simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
+      simp-vendored-r10k-gem-semantic_puppet:
+        rpm_name: simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
+      simp-vendored-r10k-gem-text:
+        rpm_name: simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
+        source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
+      sudosh2:
+        rpm_name: sudosh2-1.0.2-2el7.x86_64.rpm
+        source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/sudosh2-1.0.2-2el7.x86_64.rpm
+      syslinux-tftpboot:
+        rpm_name: syslinux-tftpboot-4.05-13.el7.x86_64.rpm
+        source: http://vault.centos.org/7.4.1708/os/x86_64/Packages/syslinux-tftpboot-4.05-13.el7.x86_64.rpm

--- a/v1/prereleases/6.0.0-Alpha-Release.yaml
+++ b/v1/prereleases/6.0.0-Alpha-Release.yaml
@@ -1,375 +1,380 @@
 ---
 releases:
   6.0.0-Alpha-Release:
-    simp-doc:
-      ref: 4418b658829a63dd98d5143430cb295454e34019
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: cbb61c8844cebd38e3593dd131e01cb084195f31
-      type: https
-      path: "/src/puppet/modules"
-    rubygem-simp-cli:
-      ref: 56cbeb366caeb88bc3294e434c5685b1114e3c9b
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: b63c0bd130897256f645d80af2bb958d2fd5448e
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: 17cf07ca3a8d3aeedeb94f3f11e9f08177fa20bd
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: d0667d5357ce0e7ff311389d7cd388354f2d255d
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: b604fab064331199208a4d2feaab92fb00ebb472
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: 5bb53a81438c9543b9f844a7f295953c0370f6ef
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: 0bbfbe8527c3c8322c735eeed2dad93293393a73
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: bebe87262e32c7a2606f0d4b4e1200921730a105
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: dfadf8d314ea7a8453011922a55162e291db22a7
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: d0e70ef244b92ec730abd2198d3590e69bd312f9
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: 82dbe6518159e080f865425da3daa250305dd26a
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: e666487674fc98ae0c530686f819174179ffe046
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: 3c7e237cb0de408f34b9afb2f301a4fa6cc6ed7c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: 3e7822e60e9ddea5383e9a1037685cb05aad08fa
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: 91a256e8aab5a76df07144fcff1e54ac9af7a815
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: ea5e3357ef5f2abf3eaa998fd39c6c61ded807ba
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: f235c7b032a6abca5b73687221a8fdf8f151691a
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-concat:
-      ref: 2c68422402e0e1e68c39a3c8cd1d085ece493635
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: c3b1dfbe73536d78e95f77731ad582e46c896bde
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: 44154f381f7d3e692dae93b5bf05d4c1d9563217
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: 625ce220bae00f1c37415d9fdacc44c7c02d65b3
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: b4478aba815d5e7e9a9f82ca0f59533e312bf954
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: ddcb257231d1a409aada5e140bb23c22eacb27e1
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: 87ad4eb015f2e2c9ef876b04156ebbd3794cf457
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 5a02c573242171c8d8210607fb19c766b2c4632f
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: 2da631be16147f153b7d0d3c52014d474e93e619
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: fe2862ce8e938ae84693328f1054098b8f0f803f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: 141c9fadf2e21a9aea917e43edaa65cdd0139cbe
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: 7482d408b5368cc16353420893c287de67bf426e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: 6975fd99e7ddbc4a2bf26321fae7ca2a200ae8da
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: c74e0e8569febc57486ae8a22c782c1bc087430f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: 822f5430882a572fae1133b731bd5623ecd4d520
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: 950b3a8bd926e7afd4cbd2f70679d0e2549a6058
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: 34bdd8a5d38c84772d523b1167e32726b9ef4b71
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dirtycow:
-      ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: b91c904128cc9a969891daadf073d0499af32456
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ganglia:
-      ref: bdfb68e0872695314129736de8c15d2656d6b1dd
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: 3d026b4faed30c2d72d795cd1e94b592314c5cb1
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: 44193cabd53f49bcb26be9e3c4845edabad486d5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: 3c9d0f5d2b28629bda77f97368d0a3b8a1dbd431
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-journald:
-      ref: 26e4c303fd7bd6c61db469cbc63616e82a6f425b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 927fbc2870586e8421ac4350044290715d3e14e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libreswan:
-      ref: 12cb4acdac893c1c57b947a06fa36022403def04
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: '0303494aae68b5ff47125ccbba5dba7baf89eb51'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: d900787b33ec2fef937d17abe96dab9998b1aa99
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: '069ab9c6f68b78140688ec09ffea963d0ab16f35'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: '068dab1c092a0245511e38a5a1db35501a06cc9c'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: ddb8b98da24de50e6d3fcb5f74f57426f359a9f3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: ca71684c69112b86d5f88ae0787bb309132f701f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 93f57115152e8a852620f4327882baa614aa83aa
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 0a0d70c7ff343d4213dea3a2dba459c4eed28d5c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nscd:
-      ref: 78efbe93b7b5da2d2eb4b0b0be0ca3d09326506f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: f86d3a1cd1c1661e9f432b46c20a740f78598c53
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 9f37230ac78d607f5eb64c14be74328246f4ca05
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openldap:
-      ref: 906d856935e5b6ea70fe3f6e05bed682e16f99f9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: f2759b9e7bcd2292bb01e9bb15584a70862285b9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: 789c416d804c22f10439303df86fc1f6ba120211
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: bade757d67d1d78a7d3f50a391cca54b745d8a9e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 8f22ecccb7cd9feec491c046f175d3dc58174033
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: 5703475467662a8a91c344f44b5bfc8e99e77e01
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: d687e7798b486b9ad7c06225fd3fc327ba392594
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: 86e9169942ce8f2b1d7a7db79e80b081f26954a5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: 28aebc8b959f716fdd6cc5939e313ae3e4b81034
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: 3fe619e4ef364193316ca023514d9f43d37bdf57
-      type: ssh
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: '0408a86292dc15284690effc3ea7182798df7f22'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: 68264d4167cd1728a3f0b783b541a9c9817412b9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: dd2ca4f8d7764f49cb7859d650ab98826a117df7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: 70be3a662d2097b3a367756b2e1bb58ec22af33e
-      type: ssh
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 389a37724e77805fe5ad242faf595e350454b976
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-snmpd:
-      ref: 8013c84bf71c940a9706e63e60d4f60505e9617e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: c1d951a9e55fc80bdc2d95d3ca42c8c847f93690
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: 4781d3cadfe46fcf87204b9c1ac6006ce7863081
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 6d3d2c7bf5bd1e6029bd149df85da2f525f050f8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: e812ccefca46e137cf3b17a7df23d082967e07ad
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: abcbf7be373012e14e229186653da4182768aabe
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: c3dced52b9ba66981c23565a7a5559b66d1757ad
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sysctl:
-      ref: f09752a4200d53f6cca67cbea176a49113e52e31
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: b8a0d2dc4d4d50a03f539355725ff61ebfdf2dd5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: aa2414f8186cdd37e79e82ebd9badd8f22704727
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 72275712eb0a7ffd37c28bdaaa6a769213874567
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: bca11cb5c9d1ed3d53c09789e9c6bc955d34ba93
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 9998f91d2f8e088681d131742a06b025c55dfb7a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: b532fa4a623ff2d42ba678b1b506cb7b2797f2cc
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-windowmanager:
-      ref: f87602c2fd1a251c380777a170090b4a40942986
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: 4bcd45204720d7f2cac43463769351d1602ca39e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xwindows:
-      ref: 8f491c11875f3192540f8739d7ca9302e84fe475
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: 16c660d5b56be37cbe44ecbfac87bfc61ed40bfd
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 4418b658829a63dd98d5143430cb295454e34019
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: cbb61c8844cebd38e3593dd131e01cb084195f31
+        type: https
+        path: "/src/puppet/modules"
+      rubygem-simp-cli:
+        ref: 56cbeb366caeb88bc3294e434c5685b1114e3c9b
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: b63c0bd130897256f645d80af2bb958d2fd5448e
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: 17cf07ca3a8d3aeedeb94f3f11e9f08177fa20bd
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: d0667d5357ce0e7ff311389d7cd388354f2d255d
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: b604fab064331199208a4d2feaab92fb00ebb472
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: 5bb53a81438c9543b9f844a7f295953c0370f6ef
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: 0bbfbe8527c3c8322c735eeed2dad93293393a73
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: bebe87262e32c7a2606f0d4b4e1200921730a105
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: dfadf8d314ea7a8453011922a55162e291db22a7
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: d0e70ef244b92ec730abd2198d3590e69bd312f9
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: 82dbe6518159e080f865425da3daa250305dd26a
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: e666487674fc98ae0c530686f819174179ffe046
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: 3c7e237cb0de408f34b9afb2f301a4fa6cc6ed7c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: 3e7822e60e9ddea5383e9a1037685cb05aad08fa
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: 91a256e8aab5a76df07144fcff1e54ac9af7a815
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: ea5e3357ef5f2abf3eaa998fd39c6c61ded807ba
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: f235c7b032a6abca5b73687221a8fdf8f151691a
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-concat:
+        ref: 2c68422402e0e1e68c39a3c8cd1d085ece493635
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: c3b1dfbe73536d78e95f77731ad582e46c896bde
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: 44154f381f7d3e692dae93b5bf05d4c1d9563217
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: 625ce220bae00f1c37415d9fdacc44c7c02d65b3
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: b4478aba815d5e7e9a9f82ca0f59533e312bf954
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: ddcb257231d1a409aada5e140bb23c22eacb27e1
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: 87ad4eb015f2e2c9ef876b04156ebbd3794cf457
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 5a02c573242171c8d8210607fb19c766b2c4632f
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: 2da631be16147f153b7d0d3c52014d474e93e619
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: fe2862ce8e938ae84693328f1054098b8f0f803f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: 141c9fadf2e21a9aea917e43edaa65cdd0139cbe
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: 7482d408b5368cc16353420893c287de67bf426e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: 6975fd99e7ddbc4a2bf26321fae7ca2a200ae8da
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: c74e0e8569febc57486ae8a22c782c1bc087430f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: 822f5430882a572fae1133b731bd5623ecd4d520
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: 950b3a8bd926e7afd4cbd2f70679d0e2549a6058
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: 34bdd8a5d38c84772d523b1167e32726b9ef4b71
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dirtycow:
+        ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: b91c904128cc9a969891daadf073d0499af32456
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ganglia:
+        ref: bdfb68e0872695314129736de8c15d2656d6b1dd
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: 3d026b4faed30c2d72d795cd1e94b592314c5cb1
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: 44193cabd53f49bcb26be9e3c4845edabad486d5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: 3c9d0f5d2b28629bda77f97368d0a3b8a1dbd431
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-journald:
+        ref: 26e4c303fd7bd6c61db469cbc63616e82a6f425b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 927fbc2870586e8421ac4350044290715d3e14e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libreswan:
+        ref: 12cb4acdac893c1c57b947a06fa36022403def04
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: '0303494aae68b5ff47125ccbba5dba7baf89eb51'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: d900787b33ec2fef937d17abe96dab9998b1aa99
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: '069ab9c6f68b78140688ec09ffea963d0ab16f35'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: '068dab1c092a0245511e38a5a1db35501a06cc9c'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: ddb8b98da24de50e6d3fcb5f74f57426f359a9f3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: ca71684c69112b86d5f88ae0787bb309132f701f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 93f57115152e8a852620f4327882baa614aa83aa
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 0a0d70c7ff343d4213dea3a2dba459c4eed28d5c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nscd:
+        ref: 78efbe93b7b5da2d2eb4b0b0be0ca3d09326506f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: f86d3a1cd1c1661e9f432b46c20a740f78598c53
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 9f37230ac78d607f5eb64c14be74328246f4ca05
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openldap:
+        ref: 906d856935e5b6ea70fe3f6e05bed682e16f99f9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: f2759b9e7bcd2292bb01e9bb15584a70862285b9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: 789c416d804c22f10439303df86fc1f6ba120211
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: bade757d67d1d78a7d3f50a391cca54b745d8a9e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 8f22ecccb7cd9feec491c046f175d3dc58174033
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: 5703475467662a8a91c344f44b5bfc8e99e77e01
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: d687e7798b486b9ad7c06225fd3fc327ba392594
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: 86e9169942ce8f2b1d7a7db79e80b081f26954a5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: 28aebc8b959f716fdd6cc5939e313ae3e4b81034
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: 3fe619e4ef364193316ca023514d9f43d37bdf57
+        type: ssh
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: '0408a86292dc15284690effc3ea7182798df7f22'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: 68264d4167cd1728a3f0b783b541a9c9817412b9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: dd2ca4f8d7764f49cb7859d650ab98826a117df7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: 70be3a662d2097b3a367756b2e1bb58ec22af33e
+        type: ssh
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 389a37724e77805fe5ad242faf595e350454b976
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-snmpd:
+        ref: 8013c84bf71c940a9706e63e60d4f60505e9617e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: c1d951a9e55fc80bdc2d95d3ca42c8c847f93690
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: 4781d3cadfe46fcf87204b9c1ac6006ce7863081
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 6d3d2c7bf5bd1e6029bd149df85da2f525f050f8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: e812ccefca46e137cf3b17a7df23d082967e07ad
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: abcbf7be373012e14e229186653da4182768aabe
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: c3dced52b9ba66981c23565a7a5559b66d1757ad
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sysctl:
+        ref: f09752a4200d53f6cca67cbea176a49113e52e31
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: b8a0d2dc4d4d50a03f539355725ff61ebfdf2dd5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: aa2414f8186cdd37e79e82ebd9badd8f22704727
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 72275712eb0a7ffd37c28bdaaa6a769213874567
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: bca11cb5c9d1ed3d53c09789e9c6bc955d34ba93
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 9998f91d2f8e088681d131742a06b025c55dfb7a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: b532fa4a623ff2d42ba678b1b506cb7b2797f2cc
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-windowmanager:
+        ref: f87602c2fd1a251c380777a170090b4a40942986
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: 4bcd45204720d7f2cac43463769351d1602ca39e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xwindows:
+        ref: 8f491c11875f3192540f8739d7ca9302e84fe475
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: 16c660d5b56be37cbe44ecbfac87bfc61ed40bfd
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-7.2-x86_64:
+      CentOS-6.8-x86_64:
+      RedHat-7.2-x86_64:

--- a/v1/prereleases/6.0.0-Beta.yaml
+++ b/v1/prereleases/6.0.0-Beta.yaml
@@ -1,427 +1,432 @@
 ---
 releases:
   6.0.0-Beta:
-    simp-doc:
-      ref: 250e75c0b3d31f094ec3165c03dabf6c23487cac
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: 510bb662128e896a78dafd7ed7ac739025118457
-      type: https
-      path: "/src/puppet/modules"
-    rubygem-simp-cli:
-      ref: 4ad5b2f176aa80ea931a8f49723361e3af6e465c
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      type: https
-      path: "/src/puppet/modules"
-    puppet-kmod:
-      ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: f235c7b032a6abca5b73687221a8fdf8f151691a
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      type: https
-      path: "/src/puppet/modules"
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-at:
-      ref: 4deddd8c4e3c5fb1320b017e6ab52828234d58be
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: fc667847581bf5bcb24f13b6cb7ae1121450191c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: 16c660d5b56be37cbe44ecbfac87bfc61ed40bfd
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dirtycow:
-      ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-fips:
-      ref: 5e749c0ba51c93bcc7570be1221d7a75937d9eeb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-gdm:
-      ref: 5d1c85bbf0d07c8402c18e627a4a73fc9fd1f84a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-gnome:
-      ref: f3a95330b79b67913a48b1a2cfe85d5582b6ed66
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      type: 
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-journald:
-      ref: 26e4c303fd7bd6c61db469cbc63616e82a6f425b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 6bd6e1a197b6fef9763b760a3cbd8970b31250be
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: 4d34e3dedf9f3bb247a69f09d45964f947ad34eb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: 782a219c13788ecc4a490d1d9ee1bed4d5fca287
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 0b7a1909223f6d03dc4093d13d2d9fee2d712fca
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 975f88b67816d547253a51c75cce136fe1a661b7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: 89d315c35148925272efdac1c0b44ff51b2dcfe4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_openldap:
-      ref: '085a7e373d6c44a39dd2698461f51a86805f771d'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: bd82f5f1a84745ea1b98407cb53f7e2cafe13dfc
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: 020dbdee9ebdf17e0303e5f8b11a0d4a1c814a87
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: 88790fe1c4ab49392eb59c2e7a8f9f343aa66aaa
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: f0d3d56d6a9e1c5dbb456f128e5763309c8b78b0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: a30e005c6c4e7438e2a3e7fc850e14a5f4c60c4a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: e5cb0fae497e4fb84528796a7031f84afd59d85a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: 5acdadfc21f06ec109c4a4a23c2945415a180ad6
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: 7c31ca566f03b438084adc693ab5c0d3f5f36e4b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_nfs:
-      ref: 5ed90c390cdf72ccc10cbe1f79dcb08a17aed4cb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_rsyslog:
-      ref: bac200cbef242f08dfc3a570680667d2812e65c0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: 7a1122b00866c3123f3b14b4fc0273972e5692c5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 6d0f0d65f5fbf2af281382f174282c98bca4c075
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: c4ad9f5f9209598a27ded66f4e72bec2f2466aad
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: 428624f9996c790e81641ede453a27ef7b5ff285
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 87f9d4fa80d1f437bc9c597ca4d0634a5f37e6a8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: a4c027eeb4cc8091c0771c9c29eb8e099acc75d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-useradd:
-      ref: 97f37c0f2c985695526907ceafd15d738c346244
-      type: https
-      path: "/src/puppet/modules"
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 250e75c0b3d31f094ec3165c03dabf6c23487cac
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: 510bb662128e896a78dafd7ed7ac739025118457
+        type: https
+        path: "/src/puppet/modules"
+      rubygem-simp-cli:
+        ref: 4ad5b2f176aa80ea931a8f49723361e3af6e465c
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        type: https
+        path: "/src/puppet/modules"
+      puppet-kmod:
+        ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: f235c7b032a6abca5b73687221a8fdf8f151691a
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        type: https
+        path: "/src/puppet/modules"
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-at:
+        ref: 4deddd8c4e3c5fb1320b017e6ab52828234d58be
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: fc667847581bf5bcb24f13b6cb7ae1121450191c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: 16c660d5b56be37cbe44ecbfac87bfc61ed40bfd
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dirtycow:
+        ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-fips:
+        ref: 5e749c0ba51c93bcc7570be1221d7a75937d9eeb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-gdm:
+        ref: 5d1c85bbf0d07c8402c18e627a4a73fc9fd1f84a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-gnome:
+        ref: f3a95330b79b67913a48b1a2cfe85d5582b6ed66
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        type: 
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-journald:
+        ref: 26e4c303fd7bd6c61db469cbc63616e82a6f425b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 6bd6e1a197b6fef9763b760a3cbd8970b31250be
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: 4d34e3dedf9f3bb247a69f09d45964f947ad34eb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: 782a219c13788ecc4a490d1d9ee1bed4d5fca287
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 0b7a1909223f6d03dc4093d13d2d9fee2d712fca
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 975f88b67816d547253a51c75cce136fe1a661b7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: 89d315c35148925272efdac1c0b44ff51b2dcfe4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_openldap:
+        ref: '085a7e373d6c44a39dd2698461f51a86805f771d'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: bd82f5f1a84745ea1b98407cb53f7e2cafe13dfc
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: 020dbdee9ebdf17e0303e5f8b11a0d4a1c814a87
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: 88790fe1c4ab49392eb59c2e7a8f9f343aa66aaa
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: f0d3d56d6a9e1c5dbb456f128e5763309c8b78b0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: a30e005c6c4e7438e2a3e7fc850e14a5f4c60c4a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: e5cb0fae497e4fb84528796a7031f84afd59d85a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: 5acdadfc21f06ec109c4a4a23c2945415a180ad6
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: 7c31ca566f03b438084adc693ab5c0d3f5f36e4b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_nfs:
+        ref: 5ed90c390cdf72ccc10cbe1f79dcb08a17aed4cb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_rsyslog:
+        ref: bac200cbef242f08dfc3a570680667d2812e65c0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: 7a1122b00866c3123f3b14b4fc0273972e5692c5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 6d0f0d65f5fbf2af281382f174282c98bca4c075
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: c4ad9f5f9209598a27ded66f4e72bec2f2466aad
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: 428624f9996c790e81641ede453a27ef7b5ff285
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 87f9d4fa80d1f437bc9c597ca4d0634a5f37e6a8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: a4c027eeb4cc8091c0771c9c29eb8e099acc75d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-useradd:
+        ref: 97f37c0f2c985695526907ceafd15d738c346244
+        type: https
+        path: "/src/puppet/modules"
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-7.3-x86_64:
+      CentOS-6.8-x86_64:
+      RedHat-7.3-x86_64:

--- a/v1/prereleases/6.0.0-RC1.yaml
+++ b/v1/prereleases/6.0.0-RC1.yaml
@@ -1,427 +1,432 @@
 ---
 releases:
   6.0.0-RC1:
-    simp-doc:
-      ref: 5019d8716aeecf2631463d8bc5b3c4bde31249c6
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: 6dd183da525da01f2fcbad8e697607bf616796f1
-      type: https
-      path: "/src/puppet/modules"
-    rubygem-simp-cli:
-      ref: 947a29af514417c4b976ebae56deb73b4c7cc64c
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      type: https
-      path: "/src/puppet/modules"
-    puppet-kmod:
-      ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      type: https
-      path: "/src/puppet/modules"
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: c64a9d841ca9083b9a8a4b179ce179822a560e02
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-fips:
-      ref: 5e749c0ba51c93bcc7570be1221d7a75937d9eeb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-gnome:
-      ref: 7465fe7485702b6b07343a287f3d0c26b1f1af99
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 6bd6e1a197b6fef9763b760a3cbd8970b31250be
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: 4d34e3dedf9f3bb247a69f09d45964f947ad34eb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: 782a219c13788ecc4a490d1d9ee1bed4d5fca287
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 4a60137434cf025631724f349dce1cca205dc1aa
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: 89d315c35148925272efdac1c0b44ff51b2dcfe4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_openldap:
-      ref: 39f99c9bc50059865c177b4c7948cc155f155695
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: 05c5312a624b602e9281504ddb51e349c24e40f9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: e35bada1c874b2ba1d548494c5b4adcb7de5a2f1
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: f0d3d56d6a9e1c5dbb456f128e5763309c8b78b0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: a30e005c6c4e7438e2a3e7fc850e14a5f4c60c4a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: 4b5aa9c40bf7f5636a003ef57825905d31bbf133
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: ccb1f64dc344e6e01609b329a1452bcada6b599b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_nfs:
-      ref: 5ed90c390cdf72ccc10cbe1f79dcb08a17aed4cb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_rsyslog:
-      ref: '058a9a416a25774840366e555399ed4da2a903ea'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: b3b30b4d858612210095c8d562597ac47463a6c8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: 77643946f5dfe7ff084460001dbe87e77e90f687
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: ad908c04429d5f3f9c7e94fa77f18239f024db28
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: 51e4a5be8338d30d9446da228d77370960508a4a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-useradd:
-      ref: 97f37c0f2c985695526907ceafd15d738c346244
-      type: https
-      path: "/src/puppet/modules"
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 5019d8716aeecf2631463d8bc5b3c4bde31249c6
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: 6dd183da525da01f2fcbad8e697607bf616796f1
+        type: https
+        path: "/src/puppet/modules"
+      rubygem-simp-cli:
+        ref: 947a29af514417c4b976ebae56deb73b4c7cc64c
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        type: https
+        path: "/src/puppet/modules"
+      puppet-kmod:
+        ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        type: https
+        path: "/src/puppet/modules"
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: c64a9d841ca9083b9a8a4b179ce179822a560e02
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-fips:
+        ref: 5e749c0ba51c93bcc7570be1221d7a75937d9eeb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-gnome:
+        ref: 7465fe7485702b6b07343a287f3d0c26b1f1af99
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 6bd6e1a197b6fef9763b760a3cbd8970b31250be
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: 4d34e3dedf9f3bb247a69f09d45964f947ad34eb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: 782a219c13788ecc4a490d1d9ee1bed4d5fca287
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 4a60137434cf025631724f349dce1cca205dc1aa
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: 89d315c35148925272efdac1c0b44ff51b2dcfe4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_openldap:
+        ref: 39f99c9bc50059865c177b4c7948cc155f155695
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: 05c5312a624b602e9281504ddb51e349c24e40f9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: e35bada1c874b2ba1d548494c5b4adcb7de5a2f1
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: f0d3d56d6a9e1c5dbb456f128e5763309c8b78b0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: a30e005c6c4e7438e2a3e7fc850e14a5f4c60c4a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: 4b5aa9c40bf7f5636a003ef57825905d31bbf133
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: ccb1f64dc344e6e01609b329a1452bcada6b599b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_nfs:
+        ref: 5ed90c390cdf72ccc10cbe1f79dcb08a17aed4cb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_rsyslog:
+        ref: '058a9a416a25774840366e555399ed4da2a903ea'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: b3b30b4d858612210095c8d562597ac47463a6c8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: 77643946f5dfe7ff084460001dbe87e77e90f687
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: ad908c04429d5f3f9c7e94fa77f18239f024db28
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: 51e4a5be8338d30d9446da228d77370960508a4a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-useradd:
+        ref: 97f37c0f2c985695526907ceafd15d738c346244
+        type: https
+        path: "/src/puppet/modules"
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-7.3-x86_64:
+      CentOS-6.8-x86_64:
+      RedHat-7.3-x86_64:

--- a/v1/prereleases/6.1.0-RC1.yaml
+++ b/v1/prereleases/6.1.0-RC1.yaml
@@ -1,225 +1,230 @@
 ---
 releases:
   6.1.0-RC1:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-    puppet-elasticsearch:
-      tag: 5.2.0
-    puppet-logstash:
-      tag: 5.2.1
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-    puppetlabs-puppet_authorization:
-      ref: master
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-    puppetlabs-stdlib:
-      tag: 4.19.0
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+      puppet-elasticsearch:
+        tag: 5.2.0
+      puppet-logstash:
+        tag: 5.2.1
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+      puppetlabs-puppet_authorization:
+        ref: master
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+      puppetlabs-stdlib:
+        tag: 4.19.0
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/prereleases/6.2.0-ALPHA1.yaml
+++ b/v1/prereleases/6.2.0-ALPHA1.yaml
@@ -1,376 +1,381 @@
 ---
 releases:
   6.2.0-ALPHA1:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      tag: 6.0.5
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-      tag: 0.0.5
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-      tag: 3.0.3
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 5.3.0
-      ref: 212439a83fa900f0212095a84a420e49d9788fc7
-    puppet-file_concat:
-      ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
-      tag: simp-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: a5e9704b594152163bcff48bc759b702914ee5a5
-      tag: 2.0.2
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: 5e2d464cee5ee723c4835b7524e4faca591cee8e
-      tag: 3.0.0
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: f75319e10ac9ee51e5b489b1ddd5a514c6f180ee
-      tag: 2.0.4
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 295de2b48986e3033d01da0de0fa6650a8870849
-      tag: 2.2.2
-    augeasproviders_ssh:
-      ref: b6268b38b6931ecb9f5a641d42f7cd9bbac530cf
-      tag: 2.5.3
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: a265ddeb8e43faf4f88e9456716ccfc6ab73c8b4
-      tag: 1.0.4
-    puppetlabs-apache:
-      ref: 295dbd9e6b70dab6eba50589f55d0fbf04ba6a13
-      tag: 2.3.1
-    puppetlabs-concat:
-      ref: 04f2871ca16f06a1f530c4901bdf4df770b69397
-      tag: 3.0.0
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: d1df767acd7aaa86c8334171eac32e53564cdf20
-      tag: 1.6.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6160665065be2720b491534d96b62f397ca1d17b
-      tag: 1.7.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      tag: 5.2.1
-    puppetlabs-stdlib:
-      tag: 4.24.0
-      ref: e46d9a4c144cbe3e979f1684d89f577f43fe9084
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      tag: 7.0.1
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: fcf03732bbefabcbcccf9fe12866df4d30d794ce
-      tag: 0.1.0
-    pupmod-simp-iptables:
-      ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
-      tag: 6.1.2
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: 02b7eec09fe36dae5d740334e76c7937ca18ffd4
-      tag: 6.3.0
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      tag: simp6.0.0-2.0.0
-    simp-rsync_data:
-      tag: 6.2.0
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-    camptocamp-systemd:
-      tag: 1.1.1
-      ref: b29c6eb2cee112a031a6780a943d43a5f335609b
-    puppetlabs-hocon:
-      tag: 0.9.4
-      ref: fe4d1aeb8104bbf78606c5a04a18bb1241b3f9fd
-    puppetlabs-mount_providers:
-      tag: 1.0.0
-      ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
-    puppetlabs-translate:
-      tag: 1.0.0
-      ref: 9455a26726954ad180d910a1269d52eccbfb941c
-    razorsedge-snmp:
-      tag: 3.9.0
-      ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
-    simp-haveged:
-      tag: 0.4.5
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-    simp-simp_apache:
-      tag: 6.0.1
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-    simp-simp_gitlab:
-      tag: 0.3.1
-      ref: 86d41b81e83edf5ffbdb96da88d37951b950eef3
-    simp-simp_snmpd:
-      tag: 0.0.2
-      ref: 9d61971ba2fc858b8d7398acabe4244d729a119a
-    simp-timezone:
-      tag: 4.0.0
-      ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
-    voxpupuli-yum:
-      tag: v2.1.0
-      ref: 2ada87203ac746e5e431b681068b8a32fb12b88d
-    vshn-gitlab:
-      tag: v1.13.3
-      ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        tag: 6.0.5
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+        tag: 0.0.5
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+        tag: 3.0.3
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 5.3.0
+        ref: 212439a83fa900f0212095a84a420e49d9788fc7
+      puppet-file_concat:
+        ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
+        tag: simp-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: a5e9704b594152163bcff48bc759b702914ee5a5
+        tag: 2.0.2
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: 5e2d464cee5ee723c4835b7524e4faca591cee8e
+        tag: 3.0.0
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: f75319e10ac9ee51e5b489b1ddd5a514c6f180ee
+        tag: 2.0.4
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 295de2b48986e3033d01da0de0fa6650a8870849
+        tag: 2.2.2
+      augeasproviders_ssh:
+        ref: b6268b38b6931ecb9f5a641d42f7cd9bbac530cf
+        tag: 2.5.3
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: a265ddeb8e43faf4f88e9456716ccfc6ab73c8b4
+        tag: 1.0.4
+      puppetlabs-apache:
+        ref: 295dbd9e6b70dab6eba50589f55d0fbf04ba6a13
+        tag: 2.3.1
+      puppetlabs-concat:
+        ref: 04f2871ca16f06a1f530c4901bdf4df770b69397
+        tag: 3.0.0
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: d1df767acd7aaa86c8334171eac32e53564cdf20
+        tag: 1.6.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6160665065be2720b491534d96b62f397ca1d17b
+        tag: 1.7.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        tag: 5.2.1
+      puppetlabs-stdlib:
+        tag: 4.24.0
+        ref: e46d9a4c144cbe3e979f1684d89f577f43fe9084
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        tag: 7.0.1
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: fcf03732bbefabcbcccf9fe12866df4d30d794ce
+        tag: 0.1.0
+      pupmod-simp-iptables:
+        ref: 8f170800f9c603205b6e12893e51aef5af93ccc7
+        tag: 6.1.2
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: 02b7eec09fe36dae5d740334e76c7937ca18ffd4
+        tag: 6.3.0
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        tag: simp6.0.0-2.0.0
+      simp-rsync_data:
+        tag: 6.2.0
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+      camptocamp-systemd:
+        tag: 1.1.1
+        ref: b29c6eb2cee112a031a6780a943d43a5f335609b
+      puppetlabs-hocon:
+        tag: 0.9.4
+        ref: fe4d1aeb8104bbf78606c5a04a18bb1241b3f9fd
+      puppetlabs-mount_providers:
+        tag: 1.0.0
+        ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
+      puppetlabs-translate:
+        tag: 1.0.0
+        ref: 9455a26726954ad180d910a1269d52eccbfb941c
+      razorsedge-snmp:
+        tag: 3.9.0
+        ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
+      simp-haveged:
+        tag: 0.4.5
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+      simp-simp_apache:
+        tag: 6.0.1
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+      simp-simp_gitlab:
+        tag: 0.3.1
+        ref: 86d41b81e83edf5ffbdb96da88d37951b950eef3
+      simp-simp_snmpd:
+        tag: 0.0.2
+        ref: 9d61971ba2fc858b8d7398acabe4244d729a119a
+      simp-timezone:
+        tag: 4.0.0
+        ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
+      voxpupuli-yum:
+        tag: v2.1.0
+        ref: 2ada87203ac746e5e431b681068b8a32fb12b88d
+      vshn-gitlab:
+        tag: v1.13.3
+        ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/prereleases/6.2.0-BETA1.yaml
+++ b/v1/prereleases/6.2.0-BETA1.yaml
@@ -1,492 +1,497 @@
 ---
 releases:
   6.2.0-BETA1:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
-      branch: master
-      tag: 6.0.5
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
-      branch: master
-      tag: 0.0.5
-    simp-environment:
-      ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
-      branch: master
-      tag: 6.2.8
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: ee69ecfab838fc3094bf122b88f7311e443bee40
-      branch: master
-      tag: 4.0.5
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    herculesteam-augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    herculesteam-augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    herculesteam-augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    herculesteam-augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    herculesteam-augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    herculesteam-augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    herculesteam-augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    herculesteam-augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 50ad9f7a315697162b2e181e3414ff139436200c
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-iptables:
-      ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-pki:
-      ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
-      branch: master
-      tag: 5.0.3
-    pupmod-simp-pupmod:
-      ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
-      branch: master
-      tag: 7.5.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 12e145658e0af8301752ee64893c0ebed144031f
-      branch: master
-      tag: 7.1.1
-    pupmod-simp-selinux:
-      ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
-      branch: master
-      tag: 2.1.2
-    pupmod-simp-simp:
-      ref: 3f448f59ac99c60d6f185e00606366500047026f
-      branch: master
-      tag: 4.4.2
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-simp_nfs:
-      ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
-      branch: master
-      tag: 3.9.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
-      branch: master
-      tag: 6.4.1
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: e53f9a98238433b26573ae32887f2122af2118a5
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: ea341333c730ce3014ab1681038cb9214096ac19
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-vnc:
-      ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    camptocamp-systemd:
-      tag: 1.1.1
-      ref: b29c6eb2cee112a031a6780a943d43a5f335609b
-    puppetlabs-hocon:
-      tag: 0.9.4
-      ref: fe4d1aeb8104bbf78606c5a04a18bb1241b3f9fd
-    puppetlabs-mount_providers:
-      tag: 1.0.0
-      ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
-    puppetlabs-translate:
-      tag: 1.0.0
-      ref: 9455a26726954ad180d910a1269d52eccbfb941c
-    razorsedge-snmp:
-      tag: 3.9.0
-      ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
-    simp-simp_gitlab:
-      tag: 0.3.1
-      ref: 86d41b81e83edf5ffbdb96da88d37951b950eef3
-    simp-simp_snmpd:
-      tag: 0.0.2
-      ref: 9d61971ba2fc858b8d7398acabe4244d729a119a
-    simp-timezone:
-      tag: 4.0.0
-      ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
-    voxpupuli-yum:
-      tag: v2.1.0
-      ref: 2ada87203ac746e5e431b681068b8a32fb12b88d
-    vshn-gitlab:
-      tag: v1.13.3
-      ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
-    rubygem-simp-metadata:
-      ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
-      tag: 0.4.3
-    rubygem-simp-rake-helpers:
-      ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
-      tag: 5.4.3
-    pkg-r10k: {}
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b1701c2141a2f4eb1638eb5b666793eabdc33c4f
+        branch: master
+        tag: 6.0.5
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: 860fa56c1286c9e9a090f39d38fdf32431bcd4bf
+        branch: master
+        tag: 0.0.5
+      simp-environment:
+        ref: 037a93538e040052c4a47ab9aa85b476f5e39cb3
+        branch: master
+        tag: 6.2.8
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: ee69ecfab838fc3094bf122b88f7311e443bee40
+        branch: master
+        tag: 4.0.5
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      herculesteam-augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      herculesteam-augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      herculesteam-augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      herculesteam-augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      herculesteam-augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      herculesteam-augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      herculesteam-augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      herculesteam-augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 50ad9f7a315697162b2e181e3414ff139436200c
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-iptables:
+        ref: c5b178f7fe4e9763df3b0b9d70116bdc3ee4abf1
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 428b24f918d31569832f2ecbf9725cd11a2bb1e7
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: c6f60a6bca3bbd278fc17350931c20c9900d3bbc
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-pki:
+        ref: 90829ce197fa436d29e105e93a6e8a37a3c0de42
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: d272b6b42f4dde7f72d1595cdd5de05c8ba1d712
+        branch: master
+        tag: 5.0.3
+      pupmod-simp-pupmod:
+        ref: 6f01599c2112f35061f4bcbe30c28c2ad4d97b79
+        branch: master
+        tag: 7.5.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 12e145658e0af8301752ee64893c0ebed144031f
+        branch: master
+        tag: 7.1.1
+      pupmod-simp-selinux:
+        ref: 9532ca2d612e25281be43d0fe82066087a3d5c00
+        branch: master
+        tag: 2.1.2
+      pupmod-simp-simp:
+        ref: 3f448f59ac99c60d6f185e00606366500047026f
+        branch: master
+        tag: 4.4.2
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 774fad86b9fc0664b39d1366b95fb5e3f8799165
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-simp_nfs:
+        ref: 1f0ac983ed8e6cb13d8467b73686b1482f893542
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: a8cffe89e73acf6d02414d85c8073e5b9ea2537d
+        branch: master
+        tag: 3.9.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: b1280e4564b8175780aa4b376ca1b9971cd3afdb
+        branch: master
+        tag: 6.4.1
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: e53f9a98238433b26573ae32887f2122af2118a5
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 69b78bebf848c97c5b8724c5ec22c77a71f7264f
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: ea341333c730ce3014ab1681038cb9214096ac19
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-vnc:
+        ref: bb08160268ac3b34edb70eb5dd95add9c7c4dfc6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      camptocamp-systemd:
+        tag: 1.1.1
+        ref: b29c6eb2cee112a031a6780a943d43a5f335609b
+      puppetlabs-hocon:
+        tag: 0.9.4
+        ref: fe4d1aeb8104bbf78606c5a04a18bb1241b3f9fd
+      puppetlabs-mount_providers:
+        tag: 1.0.0
+        ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
+      puppetlabs-translate:
+        tag: 1.0.0
+        ref: 9455a26726954ad180d910a1269d52eccbfb941c
+      razorsedge-snmp:
+        tag: 3.9.0
+        ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
+      simp-simp_gitlab:
+        tag: 0.3.1
+        ref: 86d41b81e83edf5ffbdb96da88d37951b950eef3
+      simp-simp_snmpd:
+        tag: 0.0.2
+        ref: 9d61971ba2fc858b8d7398acabe4244d729a119a
+      simp-timezone:
+        tag: 4.0.0
+        ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
+      voxpupuli-yum:
+        tag: v2.1.0
+        ref: 2ada87203ac746e5e431b681068b8a32fb12b88d
+      vshn-gitlab:
+        tag: v1.13.3
+        ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
+      rubygem-simp-metadata:
+        ref: 8a5c7ad045cbe4a25351cedde5c3517b1622a1cd
+        tag: 0.4.3
+      rubygem-simp-rake-helpers:
+        ref: 3fe49610299d21720cd86b4bc8815b6ac8f0c964
+        tag: 5.4.3
+      pkg-r10k: {}
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/prereleases/6.2.0-BETA2.yaml
+++ b/v1/prereleases/6.2.0-BETA2.yaml
@@ -1,470 +1,475 @@
 ---
 releases:
   6.2.0-BETA2:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.1.0-0
-    pupmod-simp-rsync:
-      ref: b3534c8eb35d9dd527e6459a54277feb8d614f80
-      branch: master
-      tag: 6.0.6
-    simp-rsync_skeleton:
-      ref: aaf439407429acd8a1f07d9f7505eb232a8bcd62
-      branch: master
-      tag: 6.2.1
-    simp-adapter:
-      ref: c1cb4e2cc03bc9bed0f828d4bf30fcb46b540216
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: e4ecf03a0e9d06d7bbf0c40cc20187a4014e8f5e
-      branch: master
-      tag: 6.2.9
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: def7cd96a8d9539d500be84e8fa23c000e36fbf8
-      branch: master
-      tag: 4.1.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    camptocamp-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    elastic-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    elastic-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    herculesteam-augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    herculesteam-augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    herculesteam-augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    herculesteam-augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    herculesteam-augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    herculesteam-augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    herculesteam-augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    onyxpoint-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-docker:
-      ref: 11dc4a66a86978f22ce057e5027fe20243d26916
-      tag: 1.1.0
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6ad404768699f25b6d0da60831a66cb5338043c6
-      branch: master
-      tag: 1.8.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
-      branch: master
-      tag: 5.3.0
-    puppetlabs-stdlib:
-      tag: 4.25.0
-      branch: master
-      ref: b83fda834d791f6dda4042df9f0d0425a989ed49
-    richardc-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-aide:
-      ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    simp-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 643d7a0d2321591c4eee129a532b9721b1fd1567
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: f889bc858c43efee8819bf9b616fb25c0505a0d5
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    cristifalcas-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 7c0625cb57134254109db2cc330a0106758fb763
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 208128e799f025cede61c2a56d11c9b73bb489c2
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-openscap:
-      ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
-      branch: master
-      tag: 6.0.4
-    pupmod-simp-pam:
-      ref: f1342d2ac62d98bbc23a9d58cf2a03fca025ec5b
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 139e4db9e8381ee30e5520dd7f2dabb35af9e451
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: c8f46807ba1fa5da3564e8e75736e00b0972f457
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 07cd649199f27d45f9de31798acf95c51f19efe5
-      branch: master
-      tag: 7.6.0
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: f3a24ebaabec02ec3e5919a6954a2cce5bdd743e
-      branch: master
-      tag: 7.1.2
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: 7957c04e1998db51ed495bbd0faeb7d112fc7318
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_apache:
-      ref: a0b61eb6ddc22ff810f7f47576f1677712752160
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-simp_docker:
-      ref: 9996a9b65a5b78e815783cfa27bc871c9e4b5beb
-      tag: 0.1.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      branch: master
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: c7c8b349ceec97431788b48a4267969c72fd8cc2
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: 9f74edf0e47786d3c288a51e18e14aaf76f8e81e
-      branch: master
-      tag: 3.10.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: f48c02ce3b28a18b1213bf99a2f5cf5cc7eca273
-      branch: master
-      tag: 6.4.2
-    pupmod-simp-sssd:
-      ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-stunnel:
-      ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
-      branch: master
-      tag: 6.3.1
-    pupmod-simp-sudo:
-      ref: 477e018d758eee281bbc0c5d6094b37cb44a5ac4
-      branch: master
-      tag: 5.0.5
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 76730cb848ef6558c34b619522d4a904ccaa4440
-      branch: master
-      tag: 3.2.5
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
-      branch: master
-      tag: 1.1.0
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: 6b4635a95178c2eba7bb7ba93ce468cdd0976bb6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: 25f0fe22bd9c87c4566f3ed90470ac80f5867b97
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    trlinkin-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    simp-systemd:
-      tag: 1.1.1
-      ref: b29c6eb2cee112a031a6780a943d43a5f335609b
-    puppetlabs-hocon:
-      tag: 0.9.4
-      ref: fe4d1aeb8104bbf78606c5a04a18bb1241b3f9fd
-    puppetlabs-mount_providers:
-      tag: 1.0.0
-      ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
-    puppetlabs-translate:
-      tag: 1.0.0
-      ref: 9455a26726954ad180d910a1269d52eccbfb941c
-    razorsedge-snmp:
-      tag: 3.9.0
-      ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
-    simp-simp_gitlab:
-      tag: 0.3.2
-      ref: 55064a9b81c21e8658cdf107b0beb660bbc9546e
-    simp-simp_snmpd:
-      tag: 0.0.2
-      ref: 9d61971ba2fc858b8d7398acabe4244d729a119a
-    simp-timezone:
-      tag: 4.0.0
-      ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
-    voxpupuli-yum:
-      tag: v2.1.0
-      ref: 2ada87203ac746e5e431b681068b8a32fb12b88d
-    vshn-gitlab:
-      tag: v1.13.3
-      ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
-    pkg-r10k:
-      ref: 5b1fe94c4bb701c83b99c4e1ebe50861fd78cd7a
-      tag: 2.6.2
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.1.0-0
+      pupmod-simp-rsync:
+        ref: b3534c8eb35d9dd527e6459a54277feb8d614f80
+        branch: master
+        tag: 6.0.6
+      simp-rsync_skeleton:
+        ref: aaf439407429acd8a1f07d9f7505eb232a8bcd62
+        branch: master
+        tag: 6.2.1
+      simp-adapter:
+        ref: c1cb4e2cc03bc9bed0f828d4bf30fcb46b540216
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: e4ecf03a0e9d06d7bbf0c40cc20187a4014e8f5e
+        branch: master
+        tag: 6.2.9
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: def7cd96a8d9539d500be84e8fa23c000e36fbf8
+        branch: master
+        tag: 4.1.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      camptocamp-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      elastic-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      elastic-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      herculesteam-augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      herculesteam-augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      herculesteam-augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      herculesteam-augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      herculesteam-augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      herculesteam-augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      herculesteam-augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      onyxpoint-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-docker:
+        ref: 11dc4a66a86978f22ce057e5027fe20243d26916
+        tag: 1.1.0
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6ad404768699f25b6d0da60831a66cb5338043c6
+        branch: master
+        tag: 1.8.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: eb04c05f768b67d7d655ff4d1d5da36bb391d5df
+        branch: master
+        tag: 5.3.0
+      puppetlabs-stdlib:
+        tag: 4.25.0
+        branch: master
+        ref: b83fda834d791f6dda4042df9f0d0425a989ed49
+      richardc-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-aide:
+        ref: e4fd206cfbb9c63abf311ed4a814c0f349487659
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: 74a530bf528e21fa832f439b94f16ba0b31d3140
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      simp-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 643d7a0d2321591c4eee129a532b9721b1fd1567
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: f889bc858c43efee8819bf9b616fb25c0505a0d5
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      cristifalcas-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 865e1b1e60a917478b16f4e1338cd387c75dfd4f
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 7c0625cb57134254109db2cc330a0106758fb763
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 208128e799f025cede61c2a56d11c9b73bb489c2
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-openscap:
+        ref: f6c2e737f3c01171741b4154be1ea7d85dffb3a4
+        branch: master
+        tag: 6.0.4
+      pupmod-simp-pam:
+        ref: f1342d2ac62d98bbc23a9d58cf2a03fca025ec5b
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 139e4db9e8381ee30e5520dd7f2dabb35af9e451
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: c8f46807ba1fa5da3564e8e75736e00b0972f457
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 07cd649199f27d45f9de31798acf95c51f19efe5
+        branch: master
+        tag: 7.6.0
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: f3a24ebaabec02ec3e5919a6954a2cce5bdd743e
+        branch: master
+        tag: 7.1.2
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: 7957c04e1998db51ed495bbd0faeb7d112fc7318
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_apache:
+        ref: a0b61eb6ddc22ff810f7f47576f1677712752160
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-simp_docker:
+        ref: 9996a9b65a5b78e815783cfa27bc871c9e4b5beb
+        tag: 0.1.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        branch: master
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: c7c8b349ceec97431788b48a4267969c72fd8cc2
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: 9f74edf0e47786d3c288a51e18e14aaf76f8e81e
+        branch: master
+        tag: 3.10.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: f48c02ce3b28a18b1213bf99a2f5cf5cc7eca273
+        branch: master
+        tag: 6.4.2
+      pupmod-simp-sssd:
+        ref: 4893318ab1211daaa89f77ed1a822b2c87e36d9b
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-stunnel:
+        ref: cb6bdfbce4abea1f385aee18c1e56422fec4af2a
+        branch: master
+        tag: 6.3.1
+      pupmod-simp-sudo:
+        ref: 477e018d758eee281bbc0c5d6094b37cb44a5ac4
+        branch: master
+        tag: 5.0.5
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 76730cb848ef6558c34b619522d4a904ccaa4440
+        branch: master
+        tag: 3.2.5
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: de059d272d89ad8f8cc4d96c63ad84de364ae9dd
+        branch: master
+        tag: 1.1.0
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: 6b4635a95178c2eba7bb7ba93ce468cdd0976bb6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: 25f0fe22bd9c87c4566f3ed90470ac80f5867b97
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      trlinkin-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      simp-systemd:
+        tag: 1.1.1
+        ref: b29c6eb2cee112a031a6780a943d43a5f335609b
+      puppetlabs-hocon:
+        tag: 0.9.4
+        ref: fe4d1aeb8104bbf78606c5a04a18bb1241b3f9fd
+      puppetlabs-mount_providers:
+        tag: 1.0.0
+        ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
+      puppetlabs-translate:
+        tag: 1.0.0
+        ref: 9455a26726954ad180d910a1269d52eccbfb941c
+      razorsedge-snmp:
+        tag: 3.9.0
+        ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
+      simp-simp_gitlab:
+        tag: 0.3.2
+        ref: 55064a9b81c21e8658cdf107b0beb660bbc9546e
+      simp-simp_snmpd:
+        tag: 0.0.2
+        ref: 9d61971ba2fc858b8d7398acabe4244d729a119a
+      simp-timezone:
+        tag: 4.0.0
+        ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
+      voxpupuli-yum:
+        tag: v2.1.0
+        ref: 2ada87203ac746e5e431b681068b8a32fb12b88d
+      vshn-gitlab:
+        tag: v1.13.3
+        ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
+      pkg-r10k:
+        ref: 5b1fe94c4bb701c83b99c4e1ebe50861fd78cd7a
+        tag: 2.6.2
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/prereleases/6.2.0-RC1.yaml
+++ b/v1/prereleases/6.2.0-RC1.yaml
@@ -1,464 +1,469 @@
 ---
 releases:
   6.2.0-RC1:
-    simp-core:
-      ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
-      branch: master
-      tag: 6.1.0-0
-    simp-doc:
-      ref: dfdd6a349526280922d5d81a82e743330c73dd38
-      branch: master
-      tag: 6.2.0-RC1
-    pupmod-simp-rsync:
-      ref: b3534c8eb35d9dd527e6459a54277feb8d614f80
-      branch: master
-      tag: 6.0.6
-    simp-rsync_skeleton:
-      ref: aaf439407429acd8a1f07d9f7505eb232a8bcd62
-      branch: master
-      tag: 6.2.1
-    simp-adapter:
-      ref: c1cb4e2cc03bc9bed0f828d4bf30fcb46b540216
-      branch: master
-      tag: 0.0.6
-    simp-environment:
-      ref: 86ffad13755cd6e5e97a4de683a1a1a967d50854
-      branch: master
-      tag: 6.2.10
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: caabbaacd96c9cd59d5a4b821b8dcf26c57df502
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    camptocamp-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    elastic-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    elastic-logstash:
-      tag: 5.3.0
-      branch: master
-      ref: 212439a83fa900f0212095a84a420e49d9788fc7
-    herculesteam-augeasproviders_apache:
-      ref: 4e9ff96f1fc919fb96e59d03a3180bcb70c9cf65
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    herculesteam-augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    herculesteam-augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    herculesteam-augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    herculesteam-augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_shellvar:
-      ref: 4607570dfc526ce357f1e3f3ad98e232e88a06e8
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    onyxpoint-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-docker:
-      ref: 11dc4a66a86978f22ce057e5027fe20243d26916
-      tag: 1.1.0
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: 1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: 5.4.0
-    puppetlabs-stdlib:
-      tag: 4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    richardc-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-aide:
-      ref: 64e72ac447d5b00a445750a3312183f91aede28a
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dconf:
-      ref: 66ba6f224f14211600897faca9dd784fad1b871f
-      branch: master
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    simp-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 643d7a0d2321591c4eee129a532b9721b1fd1567
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: f889bc858c43efee8819bf9b616fb25c0505a0d5
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    cristifalcas-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 943064852e1dc4aadc0829cb0ade968363802fb8
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 7c0625cb57134254109db2cc330a0106758fb763
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 8a276bbd5df0e7ca4cf1c0b766a8f3d63f54709d
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: 679e241ffbc09bd9f8dfd9ec89f9f554ea1bc5e7
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: f1342d2ac62d98bbc23a9d58cf2a03fca025ec5b
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 139e4db9e8381ee30e5520dd7f2dabb35af9e451
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: c8f46807ba1fa5da3564e8e75736e00b0972f457
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: f70b12e798122d3c315e26bf7db71c183e636ae6
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 74d6139036748257e451db316189cfe117360eb4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: 7957c04e1998db51ed495bbd0faeb7d112fc7318
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_apache:
-      ref: a0b61eb6ddc22ff810f7f47576f1677712752160
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-simp_docker:
-      ref: 9996a9b65a5b78e815783cfa27bc871c9e4b5beb
-      tag: 0.1.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 244647701c191a6a63473b7b1fa5424de7b7a776
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-      tag: 1.0.5
-    pupmod-simp-simp_ipa:
-      ref: 20d6c8510d0b8403f503eebc7c8f9725b401a00b
-      branch: master
-      tag: 0.0.1
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: c7c8b349ceec97431788b48a4267969c72fd8cc2
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: e39c474cb311627bfaafb7d24fe1534be88c1c21
-      branch: master
-      tag: 3.10.1
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 22a817680126e3ff9cd2497fbe6d3ebf92722730
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 3c2e55a187ac8f93e8df45bacdf1ec973b20fa95
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: 911a698e1e53d73dda29002b83f3776ca1e99d1a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 22d93a94ec85c6b107382b8eb9a4d808a556fb9c
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 32bf9b7b24b0bccd3bf6e3d77d94f959142b4ae3
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: ad2a812b278e9ca17d610590c2d842d735dd92de
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: 6b4635a95178c2eba7bb7ba93ce468cdd0976bb6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: 25f0fe22bd9c87c4566f3ed90470ac80f5867b97
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    trlinkin-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-      tag: simp6.0.0-2.0.0
-    simp-systemd:
-      tag: 1.1.1
-      ref: b29c6eb2cee112a031a6780a943d43a5f335609b
-    puppetlabs-hocon:
-      tag: 1.0.0
-      ref: b2d8c1bbc7c2ac50505b1b77d623ff29d6d5180d
-    puppetlabs-mount_providers:
-      tag: 1.0.0
-      ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
-    puppetlabs-translate:
-      tag: 1.0.0
-      ref: 9455a26726954ad180d910a1269d52eccbfb941c
-    razorsedge-snmp:
-      tag: 3.9.0
-      ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
-    simp-simp_gitlab:
-      tag: 0.3.3
-      ref: f4c7e619f20ffdff8cd3b123ef66cda8ef3291bb
-    simp-simp_snmpd:
-      tag: 0.0.3
-      ref: 86b72e48bccadabdb1299d69bf963a4695053754
-    simp-timezone:
-      tag: 4.0.0
-      ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
-    voxpupuli-yum:
-      tag: v2.2.1
-      ref: fc40cab9abf09eb864aab32fe420149a7353c524
-    vshn-gitlab:
-      tag: v1.13.3
-      ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
-      revision: 2016.1
+    components:
+      simp-core:
+        ref: 197843ec92b9a9c0955ee3a8b614d389eb6271be
+        branch: master
+        tag: 6.1.0-0
+      simp-doc:
+        ref: dfdd6a349526280922d5d81a82e743330c73dd38
+        branch: master
+        tag: 6.2.0-RC1
+      pupmod-simp-rsync:
+        ref: b3534c8eb35d9dd527e6459a54277feb8d614f80
+        branch: master
+        tag: 6.0.6
+      simp-rsync_skeleton:
+        ref: aaf439407429acd8a1f07d9f7505eb232a8bcd62
+        branch: master
+        tag: 6.2.1
+      simp-adapter:
+        ref: c1cb4e2cc03bc9bed0f828d4bf30fcb46b540216
+        branch: master
+        tag: 0.0.6
+      simp-environment:
+        ref: 86ffad13755cd6e5e97a4de683a1a1a967d50854
+        branch: master
+        tag: 6.2.10
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: caabbaacd96c9cd59d5a4b821b8dcf26c57df502
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      camptocamp-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      elastic-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      elastic-logstash:
+        tag: 5.3.0
+        branch: master
+        ref: 212439a83fa900f0212095a84a420e49d9788fc7
+      herculesteam-augeasproviders_apache:
+        ref: 4e9ff96f1fc919fb96e59d03a3180bcb70c9cf65
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      herculesteam-augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      herculesteam-augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      herculesteam-augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      herculesteam-augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_shellvar:
+        ref: 4607570dfc526ce357f1e3f3ad98e232e88a06e8
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      onyxpoint-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-docker:
+        ref: 11dc4a66a86978f22ce057e5027fe20243d26916
+        tag: 1.1.0
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: 1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: 5.4.0
+      puppetlabs-stdlib:
+        tag: 4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      richardc-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-aide:
+        ref: 64e72ac447d5b00a445750a3312183f91aede28a
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dconf:
+        ref: 66ba6f224f14211600897faca9dd784fad1b871f
+        branch: master
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      simp-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 643d7a0d2321591c4eee129a532b9721b1fd1567
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: f889bc858c43efee8819bf9b616fb25c0505a0d5
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      cristifalcas-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 943064852e1dc4aadc0829cb0ade968363802fb8
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 7c0625cb57134254109db2cc330a0106758fb763
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 20f654f539c3075264d9a54f4eb8fb0047c4cf31
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 8a276bbd5df0e7ca4cf1c0b766a8f3d63f54709d
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: 679e241ffbc09bd9f8dfd9ec89f9f554ea1bc5e7
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: f1342d2ac62d98bbc23a9d58cf2a03fca025ec5b
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 139e4db9e8381ee30e5520dd7f2dabb35af9e451
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: c8f46807ba1fa5da3564e8e75736e00b0972f457
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: f70b12e798122d3c315e26bf7db71c183e636ae6
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 74d6139036748257e451db316189cfe117360eb4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: 7957c04e1998db51ed495bbd0faeb7d112fc7318
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_apache:
+        ref: a0b61eb6ddc22ff810f7f47576f1677712752160
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-simp_docker:
+        ref: 9996a9b65a5b78e815783cfa27bc871c9e4b5beb
+        tag: 0.1.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 244647701c191a6a63473b7b1fa5424de7b7a776
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+        tag: 1.0.5
+      pupmod-simp-simp_ipa:
+        ref: 20d6c8510d0b8403f503eebc7c8f9725b401a00b
+        branch: master
+        tag: 0.0.1
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: c7c8b349ceec97431788b48a4267969c72fd8cc2
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: e39c474cb311627bfaafb7d24fe1534be88c1c21
+        branch: master
+        tag: 3.10.1
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 22a817680126e3ff9cd2497fbe6d3ebf92722730
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 3c2e55a187ac8f93e8df45bacdf1ec973b20fa95
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: 911a698e1e53d73dda29002b83f3776ca1e99d1a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 22d93a94ec85c6b107382b8eb9a4d808a556fb9c
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 32bf9b7b24b0bccd3bf6e3d77d94f959142b4ae3
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: ad2a812b278e9ca17d610590c2d842d735dd92de
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: 6b4635a95178c2eba7bb7ba93ce468cdd0976bb6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: 25f0fe22bd9c87c4566f3ed90470ac80f5867b97
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      trlinkin-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+        tag: simp6.0.0-2.0.0
+      simp-systemd:
+        tag: 1.1.1
+        ref: b29c6eb2cee112a031a6780a943d43a5f335609b
+      puppetlabs-hocon:
+        tag: 1.0.0
+        ref: b2d8c1bbc7c2ac50505b1b77d623ff29d6d5180d
+      puppetlabs-mount_providers:
+        tag: 1.0.0
+        ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
+      puppetlabs-translate:
+        tag: 1.0.0
+        ref: 9455a26726954ad180d910a1269d52eccbfb941c
+      razorsedge-snmp:
+        tag: 3.9.0
+        ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
+      simp-simp_gitlab:
+        tag: 0.3.3
+        ref: f4c7e619f20ffdff8cd3b123ef66cda8ef3291bb
+      simp-simp_snmpd:
+        tag: 0.0.3
+        ref: 86b72e48bccadabdb1299d69bf963a4695053754
+      simp-timezone:
+        tag: 4.0.0
+        ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
+      voxpupuli-yum:
+        tag: v2.2.1
+        ref: fc40cab9abf09eb864aab32fe420149a7353c524
+      vshn-gitlab:
+        tag: v1.13.3
+        ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
+        revision: 2016.1
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/4.2.0-1.yaml
+++ b/v1/releases/4.2.0-1.yaml
@@ -1,363 +1,367 @@
 ---
 releases:
   4.2.0-1:
-    simp-doc:
-      ref: 8cd735484da6e2a7a9f69fce1996b23670e4b915
-      type: ssh
-      path: "/"
-    simp-rsync:
-      ref: 0e549ac9cf306644c1ef1a8a51b34e818001cefe
-      type: ssh
-      path: "/"
-    rubygem-simp-cli:
-      ref: 207cdb970ad02259fec07a8c034da56bfd05cb0a
-      type: ssh
-      path: "/"
-    rubygem-simp-rake-helpers:
-      ref: 04d69ced7c1b0ee111e072638c6da4a732942c08
-      type: ssh
-      path: "/"
-    pupmod-simp-acpid:
-      ref: 7d5ffb7159afaaf8a27dfc9d08c43540898121d5
-      type: ssh
-      path: "/"
-    pupmod-simp-activemq:
-      ref: '0192e6919d17bfff3a38b9fdc1ee9185ef6d65b1'
-      type: ssh
-      path: "/"
-    pupmod-simp-aide:
-      ref: ba30f500fb7ffce025f9c80229b98ce11cb110ef
-      type: ssh
-      path: "/"
-    pupmod-simp-apache:
-      ref: 58fa532e54d623970f8a315f1c071d65c459e9ca
-      type: ssh
-      path: "/"
-    pupmod-simp-auditd:
-      ref: 3d2595451c12319a093b355c646c71f49c5060c5
-      type: ssh
-      path: "/"
-    augeasproviders:
-      ref: 5813ab82ba9adc7272f1780b9bdb176ac50987aa
-      type: ssh
-      path: "/"
-    augeasproviders_apache:
-      ref: fd31e7332fc164e9ed14812531cc1bfd1fd0571e
-      type: ssh
-      path: "/"
-    augeasproviders_base:
-      ref: 5c38730f1099c823e45bf55434b37066ed981948
-      type: ssh
-      path: "/"
-    augeasproviders_core:
-      ref: 5ccde88a4e95de0b33bb7a9052aa0a7a63cde08f
-      type: ssh
-      path: "/"
-    augeasproviders_grub:
-      ref: c6681d6c2b991c1c7fdc6eb38841627820c7f175
-      type: ssh
-      path: "/"
-    augeasproviders_mounttab:
-      ref: e43627ba1dba50161117e5ab0ac203a05a90596c
-      type: ssh
-      path: "/"
-    augeasproviders_nagios:
-      ref: 2c7d49638ec39469a1003e7d325f7f38d6648d55
-      type: ssh
-      path: "/"
-    augeasproviders_pam:
-      ref: 3837cb601afaca5cae9be467a88d03289d1e61bd
-      type: ssh
-      path: "/"
-    augeasproviders_postgresql:
-      ref: 957bbdc5b5ca1a016c934c964420e32858b755a2
-      type: ssh
-      path: "/"
-    augeasproviders_puppet:
-      ref: 6e1582f3687fc99c773891a4a64935aa985c2004
-      type: ssh
-      path: "/"
-    augeasproviders_shellvar:
-      ref: d332a6de6b43ba3e5e64f1fa855eb4f5666042dc
-      type: ssh
-      path: "/"
-    augeasproviders_ssh:
-      ref: 79a33d5b8dcb0051006822ea8214c8b016ed0cf2
-      type: ssh
-      path: "/"
-    augeasproviders_sysctl:
-      ref: 1bdad66a72bb0a7a556cd10c57457dfa9908656f
-      type: ssh
-      path: "/"
-    pupmod-simp-autofs:
-      ref: fe82a8858c14613aa5f4b6bb607f3ac56cf41f40
-      type: ssh
-      path: "/"
-    pupmod-simp-backuppc:
-      ref: 7b58e2254dcfa277b84258966aa14ebff90e4458
-      type: ssh
-      path: "/"
-    pupmod-simp-cgroups:
-      ref: 2867cdb86cb6033345076e8733350ceac67ebe61
-      type: ssh
-      path: "/"
-    pupmod-simp-clamav:
-      ref: 175272798ff52acbe7dcd1cb7842fb9a29db37c2
-      type: ssh
-      path: "/"
-    pupmod-simp-concat:
-      ref: 148e368649ca1f86b562392015c16d3a68e8ea39
-      type: ssh
-      path: "/"
-    puppet-datacat:
-      ref: 2a4d19093cce94c4ab75033ac5422458c3fc1c0c
-      type: ssh
-      path: "/"
-    pupmod-simp-dhcp:
-      ref: b58152e3c0894bdff5270ad983f426b1517fbff9
-      type: ssh
-      path: "/"
-    puppet-elasticsearch:
-      ref: e923d23b77f79355ca615d605a9f4e94ac78a315
-      type: ssh
-      path: "/"
-    pupmod-simp-freeradius:
-      ref: 1a6fc04b288fbb9245de79726c4ad2d546a5afc7
-      type: ssh
-      path: "/"
-    pupmod-simp-ganglia:
-      ref: f991b4fdbd436b85001f51de8971e4ac8e7f45dc
-      type: ssh
-      path: "/"
-    pupmod-simp-gfs2:
-      ref: 9629c2905148a637a457d099d07af13c33cf981d
-      type: ssh
-      path: "/"
-    puppet-gpasswd:
-      ref: 68bc6fbb9d1b6e4cedbc84df2f40517819d14d28
-      type: ssh
-      path: "/"
-    puppetlabs-inifile:
-      ref: 821bad1cccfac9c9a46917d6b304d6a99878d60e
-      type: ssh
-      path: "/"
-    pupmod-simp-iptables:
-      ref: c3c285bb016af42eb8d6064e2c0ac37eb5f70735
-      type: ssh
-      path: "/"
-    puppetlabs-java:
-      ref: d32802e712566abfcbe856479958f72c670891b9
-      type: ssh
-      path: "/"
-    puppetlabs-java_ks:
-      ref: fc27f094a3e1247937ec1b7fcf784ca6ee0dce3a
-      type: ssh
-      path: "/"
-    pupmod-simp-jenkins:
-      ref: 34a04976ea0ae4b00c5b732348c6ddec725a675c
-      type: ssh
-      path: "/"
-    pupmod-simp-kibana:
-      ref: f4163fee22714f5f86cc6f7b23388cc269c3f172
-      type: ssh
-      path: "/"
-    pupmod-simp-krb5:
-      ref: df44d53c3f0af7a1094ffc63e7cc1e365907fcd8
-      type: ssh
-      path: "/"
-    pupmod-simp-libvirt:
-      ref: c30b56e6d9394e867dd32371750543cf071d96db
-      type: ssh
-      path: "/"
-    pupmod-simp-logrotate:
-      ref: cd0ddf53f6923ec836cdd0274470771d47d0ccb7
-      type: ssh
-      path: "/"
-    puppet-logstash:
-      ref: 9e95519fb97f3382daa3e096a752515c3075b654
-      type: ssh
-      path: "/"
-    pupmod-simp-mcafee:
-      ref: 1bfb163a80e22729410beba4349a468ed2e007d1
-      type: ssh
-      path: "/"
-    pupmod-simp-mcollective:
-      ref: 51b72616871d46230bbda8dea44339d47428bf6c
-      type: ssh
-      path: "/"
-    puppet-memcached:
-      ref: 066dbbf7c2e50aaf37acdec765e4cc84eebe2ebd
-      type: ssh
-      path: "/"
-    pupmod-simp-mozilla:
-      ref: 53a7c864a7001d86ef5a1bf983ca8e9515cd7b39
-      type: ssh
-      path: "/"
-    pupmod-simp-multipathd:
-      ref: 4e406ac68f9ac28f305939fa83ef0846a0f07fa1
-      type: ssh
-      path: "/"
-    puppetlabs-mysql:
-      ref: 0701aa404ce36905426157b65472b0be243d2d24
-      type: ssh
-      path: "/"
-    pupmod-simp-named:
-      ref: 06d835595a89798ee7d610796418970e89f392ae
-      type: ssh
-      path: "/"
-    pupmod-simp-network:
-      ref: 0d64e947f90c9fb1ea07e693f4620d78eba2d992
-      type: ssh
-      path: "/"
-    pupmod-simp-nfs:
-      ref: 533e38087767782c1b2a04b48ba1428829c4b313
-      type: ssh
-      path: "/"
-    pupmod-simp-nscd:
-      ref: 1b51b382d421abb3895939237438b247f17cd222
-      type: ssh
-      path: "/"
-    pupmod-simp-ntpd:
-      ref: 9e025efbf58683e4e46f74ce7967bf39e15908b4
-      type: ssh
-      path: "/"
-    pupmod-simp-oddjob:
-      ref: '09db628593364006e249a8424789dedd03a2c066'
-      type: ssh
-      path: "/"
-    pupmod-simp-openldap:
-      ref: 1e8b8c731d8a3b51022edcd3612daf352ce7bd3b
-      type: ssh
-      path: "/"
-    pupmod-simp-openscap:
-      ref: 0ca34cd1b9f4975668747980d30b43b9eb46abe4
-      type: ssh
-      path: "/"
-    pupmod-simp-pam:
-      ref: 98ba112c7637e464778ad1f6e3515f5a804271d0
-      type: ssh
-      path: "/"
-    pupmod-simp-pki:
-      ref: bd130eae92158f0bb9466b84371071d36cbabd72
-      type: ssh
-      path: "/"
-    pupmod-simp-polkit:
-      ref: 9535c0c4d39a5d410eae037934f0f5c61791f180
-      type: ssh
-      path: "/"
-    pupmod-simp-postfix:
-      ref: ff3ab74de2d9e65f8ec576e6beb14128623f2901
-      type: ssh
-      path: "/"
-    puppetlabs-postgresql:
-      ref: 06b31e750349b884ef6221b37fdb77c5e8093142
-      type: ssh
-      path: "/"
-    pupmod-simp-pupmod:
-      ref: 569505f2bdd3d9419569619efdae558fa084d103
-      type: ssh
-      path: "/"
-    puppetlabs-puppetdb:
-      ref: 2fdaacaf0ef575a635f78f8b9bdfb606cb36213f
-      type: ssh
-      path: "/"
-    puppetlabs-apache:
-      ref: 8c2a381b9e70b8093c18e4225e393edc1f63f489
-      type: ssh
-      path: "/"
-    pupmod-simp-rsync:
-      ref: 8ad5c02b32154abc169a48a4d9675966ad744872
-      type: ssh
-      path: "/"
-    pupmod-simp-rsyslog:
-      ref: 7acfec72f0a97d7090a17529f6d0f4be8e94bbd4
-      type: ssh
-      path: "/"
-    pupmod-simp-selinux:
-      ref: '06338e06cc9786a8ac56954c84d2db1596656fe9'
-      type: ssh
-      path: "/"
-    pupmod-simp-simp:
-      ref: 6e0eaa9f77dfba9f38024c6c80cd67757d1f1028
-      type: ssh
-      path: "/"
-    pupmod-simp-simplib:
-      ref: 446928360ea287f61034ad370be8c44608b4d5f4
-      type: ssh
-      path: "/"
-    pupmod-simp-site:
-      ref: b842b6ecf587fbd80ced249d96e1d9b9bcacd637
-      type: ssh
-      path: "/"
-    pupmod-simp-snmpd:
-      ref: 01a86ef7620c9946758d8001f444c102fa16bc44
-      type: ssh
-      path: "/"
-    pupmod-simp-ssh:
-      ref: 8df25c8af0c252b5648a6b74020f47fb2d93bb1d
-      type: ssh
-      path: "/"
-    pupmod-simp-sssd:
-      ref: e58a5c90078abdcfdb61aa61e6195368c2fb8ede
-      type: ssh
-      path: "/"
-    puppetlabs-stdlib:
-      ref: 6aec7aa283c0d281fce4c51a12d033b416adab27
-      type: ssh
-      path: "/"
-    pupmod-simp-stunnel:
-      ref: 5068902a45f0875e8c5e3ae18ea5ff29102c9230
-      type: ssh
-      path: "/"
-    pupmod-simp-sudo:
-      ref: 8ff46f3dafc4ef7198dacc6cad9fe7501547cd30
-      type: ssh
-      path: "/"
-    pupmod-simp-sudosh:
-      ref: d9fd0664ffc26f1913cf85934103fe55c673b2de
-      type: ssh
-      path: "/"
-    pupmod-simp-svckill:
-      ref: 37c2afd9f1ef5155462125fb86b7b2cae3ebff37
-      type: ssh
-      path: "/"
-    pupmod-simp-sysctl:
-      ref: ba20ee55f70c399824b17625c58993fd320b906c
-      type: ssh
-      path: "/"
-    pupmod-simp-tcpwrappers:
-      ref: 17891f10ed2d1ca27fea2373180933ebe11c1b99
-      type: ssh
-      path: "/"
-    pupmod-simp-tftpboot:
-      ref: 054c0c524840ce66d3a92994217d46599efbd3cb
-      type: ssh
-      path: "/"
-    pupmod-simp-tpm:
-      ref: fa9a536980d8a12f35ecd0a77d4e35df9b4b6352
-      type: ssh
-      path: "/"
-    pupmod-simp-upstart:
-      ref: 1ed0bc5155f3fd33282855473698aeb176801260
-      type: ssh
-      path: "/"
-    pupmod-simp-vnc:
-      ref: 0d1660fd20814f83fd95338ed15edd7d26cf701a
-      type: ssh
-      path: "/"
-    pupmod-simp-vsftpd:
-      ref: 39cccf7c530121c8374f313722bb77898b40d20a
-      type: ssh
-      path: "/"
-    pupmod-simp-windowmanager:
-      ref: 751d28c54ed92c3f04cda9aa4df68f7f029aee0b
-      type: ssh
-      path: "/"
-    pupmod-simp-xinetd:
-      ref: 1956084cf3c131e6eb1af9dc3ac94f385cf5db38
-      type: ssh
-      path: "/"
-    pupmod-simp-xwindows:
-      ref: e45f5e81e94fe4b29f98ca57c43388bb1a8e3f30
-      type: ssh
-      path: "/"
+    components:
+      simp-doc:
+        ref: 8cd735484da6e2a7a9f69fce1996b23670e4b915
+        type: ssh
+        path: "/"
+      simp-rsync:
+        ref: 0e549ac9cf306644c1ef1a8a51b34e818001cefe
+        type: ssh
+        path: "/"
+      rubygem-simp-cli:
+        ref: 207cdb970ad02259fec07a8c034da56bfd05cb0a
+        type: ssh
+        path: "/"
+      rubygem-simp-rake-helpers:
+        ref: 04d69ced7c1b0ee111e072638c6da4a732942c08
+        type: ssh
+        path: "/"
+      pupmod-simp-acpid:
+        ref: 7d5ffb7159afaaf8a27dfc9d08c43540898121d5
+        type: ssh
+        path: "/"
+      pupmod-simp-activemq:
+        ref: '0192e6919d17bfff3a38b9fdc1ee9185ef6d65b1'
+        type: ssh
+        path: "/"
+      pupmod-simp-aide:
+        ref: ba30f500fb7ffce025f9c80229b98ce11cb110ef
+        type: ssh
+        path: "/"
+      pupmod-simp-apache:
+        ref: 58fa532e54d623970f8a315f1c071d65c459e9ca
+        type: ssh
+        path: "/"
+      pupmod-simp-auditd:
+        ref: 3d2595451c12319a093b355c646c71f49c5060c5
+        type: ssh
+        path: "/"
+      augeasproviders:
+        ref: 5813ab82ba9adc7272f1780b9bdb176ac50987aa
+        type: ssh
+        path: "/"
+      augeasproviders_apache:
+        ref: fd31e7332fc164e9ed14812531cc1bfd1fd0571e
+        type: ssh
+        path: "/"
+      augeasproviders_base:
+        ref: 5c38730f1099c823e45bf55434b37066ed981948
+        type: ssh
+        path: "/"
+      augeasproviders_core:
+        ref: 5ccde88a4e95de0b33bb7a9052aa0a7a63cde08f
+        type: ssh
+        path: "/"
+      augeasproviders_grub:
+        ref: c6681d6c2b991c1c7fdc6eb38841627820c7f175
+        type: ssh
+        path: "/"
+      augeasproviders_mounttab:
+        ref: e43627ba1dba50161117e5ab0ac203a05a90596c
+        type: ssh
+        path: "/"
+      augeasproviders_nagios:
+        ref: 2c7d49638ec39469a1003e7d325f7f38d6648d55
+        type: ssh
+        path: "/"
+      augeasproviders_pam:
+        ref: 3837cb601afaca5cae9be467a88d03289d1e61bd
+        type: ssh
+        path: "/"
+      augeasproviders_postgresql:
+        ref: 957bbdc5b5ca1a016c934c964420e32858b755a2
+        type: ssh
+        path: "/"
+      augeasproviders_puppet:
+        ref: 6e1582f3687fc99c773891a4a64935aa985c2004
+        type: ssh
+        path: "/"
+      augeasproviders_shellvar:
+        ref: d332a6de6b43ba3e5e64f1fa855eb4f5666042dc
+        type: ssh
+        path: "/"
+      augeasproviders_ssh:
+        ref: 79a33d5b8dcb0051006822ea8214c8b016ed0cf2
+        type: ssh
+        path: "/"
+      augeasproviders_sysctl:
+        ref: 1bdad66a72bb0a7a556cd10c57457dfa9908656f
+        type: ssh
+        path: "/"
+      pupmod-simp-autofs:
+        ref: fe82a8858c14613aa5f4b6bb607f3ac56cf41f40
+        type: ssh
+        path: "/"
+      pupmod-simp-backuppc:
+        ref: 7b58e2254dcfa277b84258966aa14ebff90e4458
+        type: ssh
+        path: "/"
+      pupmod-simp-cgroups:
+        ref: 2867cdb86cb6033345076e8733350ceac67ebe61
+        type: ssh
+        path: "/"
+      pupmod-simp-clamav:
+        ref: 175272798ff52acbe7dcd1cb7842fb9a29db37c2
+        type: ssh
+        path: "/"
+      pupmod-simp-concat:
+        ref: 148e368649ca1f86b562392015c16d3a68e8ea39
+        type: ssh
+        path: "/"
+      puppet-datacat:
+        ref: 2a4d19093cce94c4ab75033ac5422458c3fc1c0c
+        type: ssh
+        path: "/"
+      pupmod-simp-dhcp:
+        ref: b58152e3c0894bdff5270ad983f426b1517fbff9
+        type: ssh
+        path: "/"
+      puppet-elasticsearch:
+        ref: e923d23b77f79355ca615d605a9f4e94ac78a315
+        type: ssh
+        path: "/"
+      pupmod-simp-freeradius:
+        ref: 1a6fc04b288fbb9245de79726c4ad2d546a5afc7
+        type: ssh
+        path: "/"
+      pupmod-simp-ganglia:
+        ref: f991b4fdbd436b85001f51de8971e4ac8e7f45dc
+        type: ssh
+        path: "/"
+      pupmod-simp-gfs2:
+        ref: 9629c2905148a637a457d099d07af13c33cf981d
+        type: ssh
+        path: "/"
+      puppet-gpasswd:
+        ref: 68bc6fbb9d1b6e4cedbc84df2f40517819d14d28
+        type: ssh
+        path: "/"
+      puppetlabs-inifile:
+        ref: 821bad1cccfac9c9a46917d6b304d6a99878d60e
+        type: ssh
+        path: "/"
+      pupmod-simp-iptables:
+        ref: c3c285bb016af42eb8d6064e2c0ac37eb5f70735
+        type: ssh
+        path: "/"
+      puppetlabs-java:
+        ref: d32802e712566abfcbe856479958f72c670891b9
+        type: ssh
+        path: "/"
+      puppetlabs-java_ks:
+        ref: fc27f094a3e1247937ec1b7fcf784ca6ee0dce3a
+        type: ssh
+        path: "/"
+      pupmod-simp-jenkins:
+        ref: 34a04976ea0ae4b00c5b732348c6ddec725a675c
+        type: ssh
+        path: "/"
+      pupmod-simp-kibana:
+        ref: f4163fee22714f5f86cc6f7b23388cc269c3f172
+        type: ssh
+        path: "/"
+      pupmod-simp-krb5:
+        ref: df44d53c3f0af7a1094ffc63e7cc1e365907fcd8
+        type: ssh
+        path: "/"
+      pupmod-simp-libvirt:
+        ref: c30b56e6d9394e867dd32371750543cf071d96db
+        type: ssh
+        path: "/"
+      pupmod-simp-logrotate:
+        ref: cd0ddf53f6923ec836cdd0274470771d47d0ccb7
+        type: ssh
+        path: "/"
+      puppet-logstash:
+        ref: 9e95519fb97f3382daa3e096a752515c3075b654
+        type: ssh
+        path: "/"
+      pupmod-simp-mcafee:
+        ref: 1bfb163a80e22729410beba4349a468ed2e007d1
+        type: ssh
+        path: "/"
+      pupmod-simp-mcollective:
+        ref: 51b72616871d46230bbda8dea44339d47428bf6c
+        type: ssh
+        path: "/"
+      puppet-memcached:
+        ref: 066dbbf7c2e50aaf37acdec765e4cc84eebe2ebd
+        type: ssh
+        path: "/"
+      pupmod-simp-mozilla:
+        ref: 53a7c864a7001d86ef5a1bf983ca8e9515cd7b39
+        type: ssh
+        path: "/"
+      pupmod-simp-multipathd:
+        ref: 4e406ac68f9ac28f305939fa83ef0846a0f07fa1
+        type: ssh
+        path: "/"
+      puppetlabs-mysql:
+        ref: 0701aa404ce36905426157b65472b0be243d2d24
+        type: ssh
+        path: "/"
+      pupmod-simp-named:
+        ref: 06d835595a89798ee7d610796418970e89f392ae
+        type: ssh
+        path: "/"
+      pupmod-simp-network:
+        ref: 0d64e947f90c9fb1ea07e693f4620d78eba2d992
+        type: ssh
+        path: "/"
+      pupmod-simp-nfs:
+        ref: 533e38087767782c1b2a04b48ba1428829c4b313
+        type: ssh
+        path: "/"
+      pupmod-simp-nscd:
+        ref: 1b51b382d421abb3895939237438b247f17cd222
+        type: ssh
+        path: "/"
+      pupmod-simp-ntpd:
+        ref: 9e025efbf58683e4e46f74ce7967bf39e15908b4
+        type: ssh
+        path: "/"
+      pupmod-simp-oddjob:
+        ref: '09db628593364006e249a8424789dedd03a2c066'
+        type: ssh
+        path: "/"
+      pupmod-simp-openldap:
+        ref: 1e8b8c731d8a3b51022edcd3612daf352ce7bd3b
+        type: ssh
+        path: "/"
+      pupmod-simp-openscap:
+        ref: 0ca34cd1b9f4975668747980d30b43b9eb46abe4
+        type: ssh
+        path: "/"
+      pupmod-simp-pam:
+        ref: 98ba112c7637e464778ad1f6e3515f5a804271d0
+        type: ssh
+        path: "/"
+      pupmod-simp-pki:
+        ref: bd130eae92158f0bb9466b84371071d36cbabd72
+        type: ssh
+        path: "/"
+      pupmod-simp-polkit:
+        ref: 9535c0c4d39a5d410eae037934f0f5c61791f180
+        type: ssh
+        path: "/"
+      pupmod-simp-postfix:
+        ref: ff3ab74de2d9e65f8ec576e6beb14128623f2901
+        type: ssh
+        path: "/"
+      puppetlabs-postgresql:
+        ref: 06b31e750349b884ef6221b37fdb77c5e8093142
+        type: ssh
+        path: "/"
+      pupmod-simp-pupmod:
+        ref: 569505f2bdd3d9419569619efdae558fa084d103
+        type: ssh
+        path: "/"
+      puppetlabs-puppetdb:
+        ref: 2fdaacaf0ef575a635f78f8b9bdfb606cb36213f
+        type: ssh
+        path: "/"
+      puppetlabs-apache:
+        ref: 8c2a381b9e70b8093c18e4225e393edc1f63f489
+        type: ssh
+        path: "/"
+      pupmod-simp-rsync:
+        ref: 8ad5c02b32154abc169a48a4d9675966ad744872
+        type: ssh
+        path: "/"
+      pupmod-simp-rsyslog:
+        ref: 7acfec72f0a97d7090a17529f6d0f4be8e94bbd4
+        type: ssh
+        path: "/"
+      pupmod-simp-selinux:
+        ref: '06338e06cc9786a8ac56954c84d2db1596656fe9'
+        type: ssh
+        path: "/"
+      pupmod-simp-simp:
+        ref: 6e0eaa9f77dfba9f38024c6c80cd67757d1f1028
+        type: ssh
+        path: "/"
+      pupmod-simp-simplib:
+        ref: 446928360ea287f61034ad370be8c44608b4d5f4
+        type: ssh
+        path: "/"
+      pupmod-simp-site:
+        ref: b842b6ecf587fbd80ced249d96e1d9b9bcacd637
+        type: ssh
+        path: "/"
+      pupmod-simp-snmpd:
+        ref: 01a86ef7620c9946758d8001f444c102fa16bc44
+        type: ssh
+        path: "/"
+      pupmod-simp-ssh:
+        ref: 8df25c8af0c252b5648a6b74020f47fb2d93bb1d
+        type: ssh
+        path: "/"
+      pupmod-simp-sssd:
+        ref: e58a5c90078abdcfdb61aa61e6195368c2fb8ede
+        type: ssh
+        path: "/"
+      puppetlabs-stdlib:
+        ref: 6aec7aa283c0d281fce4c51a12d033b416adab27
+        type: ssh
+        path: "/"
+      pupmod-simp-stunnel:
+        ref: 5068902a45f0875e8c5e3ae18ea5ff29102c9230
+        type: ssh
+        path: "/"
+      pupmod-simp-sudo:
+        ref: 8ff46f3dafc4ef7198dacc6cad9fe7501547cd30
+        type: ssh
+        path: "/"
+      pupmod-simp-sudosh:
+        ref: d9fd0664ffc26f1913cf85934103fe55c673b2de
+        type: ssh
+        path: "/"
+      pupmod-simp-svckill:
+        ref: 37c2afd9f1ef5155462125fb86b7b2cae3ebff37
+        type: ssh
+        path: "/"
+      pupmod-simp-sysctl:
+        ref: ba20ee55f70c399824b17625c58993fd320b906c
+        type: ssh
+        path: "/"
+      pupmod-simp-tcpwrappers:
+        ref: 17891f10ed2d1ca27fea2373180933ebe11c1b99
+        type: ssh
+        path: "/"
+      pupmod-simp-tftpboot:
+        ref: 054c0c524840ce66d3a92994217d46599efbd3cb
+        type: ssh
+        path: "/"
+      pupmod-simp-tpm:
+        ref: fa9a536980d8a12f35ecd0a77d4e35df9b4b6352
+        type: ssh
+        path: "/"
+      pupmod-simp-upstart:
+        ref: 1ed0bc5155f3fd33282855473698aeb176801260
+        type: ssh
+        path: "/"
+      pupmod-simp-vnc:
+        ref: 0d1660fd20814f83fd95338ed15edd7d26cf701a
+        type: ssh
+        path: "/"
+      pupmod-simp-vsftpd:
+        ref: 39cccf7c530121c8374f313722bb77898b40d20a
+        type: ssh
+        path: "/"
+      pupmod-simp-windowmanager:
+        ref: 751d28c54ed92c3f04cda9aa4df68f7f029aee0b
+        type: ssh
+        path: "/"
+      pupmod-simp-xinetd:
+        ref: 1956084cf3c131e6eb1af9dc3ac94f385cf5db38
+        type: ssh
+        path: "/"
+      pupmod-simp-xwindows:
+        ref: e45f5e81e94fe4b29f98ca57c43388bb1a8e3f30
+        type: ssh
+        path: "/"
+    platforms:
+      CentOS-6.7-x86_64:
+      RedHat-6.7-x86_64:

--- a/v1/releases/4.2.0-2.yaml
+++ b/v1/releases/4.2.0-2.yaml
@@ -1,371 +1,375 @@
 ---
 releases:
   4.2.0-2:
-    simp-doc:
-      ref: 5f2f6fb48e74006fb9cb3018624069287f8a526c
-      type: ssh
-      path: "/"
-    simp-rsync:
-      ref: 977e9eb575dc2a556fd3c0695f967b947252c180
-      type: ssh
-      path: "/"
-    rubygem-simp-cli:
-      ref: 97f01588c11ffd08a6660eb6d13dbcfb86688416
-      type: ssh
-      path: "/"
-    rubygem-simp-rake-helpers:
-      ref: 58ae09bd62e2c842e596f3f04c0486285818feb7
-      type: ssh
-      path: "/"
-    pupmod-simp-acpid:
-      ref: fede42bc5b2898418cde3a955f5c2457909be2a3
-      type: ssh
-      path: "/"
-    pupmod-simp-activemq:
-      ref: c8c1228313b1435e6de2a32dbfe813dac9cfcfac
-      type: ssh
-      path: "/"
-    pupmod-simp-aide:
-      ref: 6881ed821a39e5f455d49f7a19e0a03f23d2e674
-      type: ssh
-      path: "/"
-    pupmod-simp-apache:
-      ref: e581d98015ca6e2e47dacf3497d34f341ee6ab79
-      type: ssh
-      path: "/"
-    pupmod-simp-auditd:
-      ref: 6e53bf42173ac4b8a1e28b146347ba3cd11013e3
-      type: ssh
-      path: "/"
-    augeasproviders:
-      ref: 5813ab82ba9adc7272f1780b9bdb176ac50987aa
-      type: ssh
-      path: "/"
-    augeasproviders_apache:
-      ref: fd31e7332fc164e9ed14812531cc1bfd1fd0571e
-      type: ssh
-      path: "/"
-    augeasproviders_base:
-      ref: 5c38730f1099c823e45bf55434b37066ed981948
-      type: ssh
-      path: "/"
-    augeasproviders_core:
-      ref: 5ccde88a4e95de0b33bb7a9052aa0a7a63cde08f
-      type: ssh
-      path: "/"
-    augeasproviders_grub:
-      ref: fce9b2eabd3c1d3c9a09c4f1f5862ec11d4b06bb
-      type: ssh
-      path: "/"
-    augeasproviders_mounttab:
-      ref: e43627ba1dba50161117e5ab0ac203a05a90596c
-      type: ssh
-      path: "/"
-    augeasproviders_nagios:
-      ref: 2c7d49638ec39469a1003e7d325f7f38d6648d55
-      type: ssh
-      path: "/"
-    augeasproviders_pam:
-      ref: 3837cb601afaca5cae9be467a88d03289d1e61bd
-      type: ssh
-      path: "/"
-    augeasproviders_postgresql:
-      ref: 957bbdc5b5ca1a016c934c964420e32858b755a2
-      type: ssh
-      path: "/"
-    augeasproviders_puppet:
-      ref: 6e1582f3687fc99c773891a4a64935aa985c2004
-      type: ssh
-      path: "/"
-    augeasproviders_shellvar:
-      ref: d332a6de6b43ba3e5e64f1fa855eb4f5666042dc
-      type: ssh
-      path: "/"
-    augeasproviders_ssh:
-      ref: 79a33d5b8dcb0051006822ea8214c8b016ed0cf2
-      type: ssh
-      path: "/"
-    augeasproviders_sysctl:
-      ref: df7ce67de6bd3ee99c188e223c2e9c06d2b25877
-      type: ssh
-      path: "/"
-    pupmod-simp-autofs:
-      ref: 61224db6dac462966574869fc153c4530585c47b
-      type: ssh
-      path: "/"
-    pupmod-simp-backuppc:
-      ref: 7b58e2254dcfa277b84258966aa14ebff90e4458
-      type: ssh
-      path: "/"
-    pupmod-simp-cgroups:
-      ref: 2867cdb86cb6033345076e8733350ceac67ebe61
-      type: ssh
-      path: "/"
-    pupmod-simp-clamav:
-      ref: dcda570b4eafa2a512a2f5310c61f449193d835a
-      type: ssh
-      path: "/"
-    pupmod-simp-concat:
-      ref: 148e368649ca1f86b562392015c16d3a68e8ea39
-      type: ssh
-      path: "/"
-    puppet-datacat:
-      ref: 2a4d19093cce94c4ab75033ac5422458c3fc1c0c
-      type: ssh
-      path: "/"
-    pupmod-simp-dhcp:
-      ref: 31f355a175b562ba1e167779b193bf57785c78ff
-      type: ssh
-      path: "/"
-    puppet-elasticsearch:
-      ref: e923d23b77f79355ca615d605a9f4e94ac78a315
-      type: ssh
-      path: "/"
-    pupmod-simp-foreman:
-      ref: abecc39bfa1cf4526026414b4da2552b95ab5c50
-      type: ssh
-      path: "/"
-    pupmod-simp-freeradius:
-      ref: c7d369fc663f71fe8ac1260e7ccc53476d19f1eb
-      type: ssh
-      path: "/"
-    pupmod-simp-ganglia:
-      ref: da32cef6cd0768cc906dbc932bafd3d75b470013
-      type: ssh
-      path: "/"
-    pupmod-simp-gfs2:
-      ref: 9629c2905148a637a457d099d07af13c33cf981d
-      type: ssh
-      path: "/"
-    puppet-gpasswd:
-      ref: 68bc6fbb9d1b6e4cedbc84df2f40517819d14d28
-      type: ssh
-      path: "/"
-    puppetlabs-inifile:
-      ref: 821bad1cccfac9c9a46917d6b304d6a99878d60e
-      type: ssh
-      path: "/"
-    pupmod-simp-iptables:
-      ref: 893e645994108c18ed2d45fe295ce0d79e25def5
-      type: ssh
-      path: "/"
-    puppetlabs-java:
-      ref: d32802e712566abfcbe856479958f72c670891b9
-      type: ssh
-      path: "/"
-    puppetlabs-java_ks:
-      ref: 4ed1045f8aef04cbd86a74fa524c20c77e4a4caf
-      type: ssh
-      path: "/"
-    pupmod-simp-jenkins:
-      ref: 34a04976ea0ae4b00c5b732348c6ddec725a675c
-      type: ssh
-      path: "/"
-    pupmod-simp-kibana:
-      ref: 275ee292b2e9eda627b422e13fbdddbf262e1bc9
-      type: ssh
-      path: "/"
-    pupmod-simp-krb5:
-      ref: df44d53c3f0af7a1094ffc63e7cc1e365907fcd8
-      type: ssh
-      path: "/"
-    pupmod-simp-libvirt:
-      ref: c30b56e6d9394e867dd32371750543cf071d96db
-      type: ssh
-      path: "/"
-    pupmod-simp-logrotate:
-      ref: 077437dcd6f4c845af064885fb25dde95c843993
-      type: ssh
-      path: "/"
-    puppet-logstash:
-      ref: 9e95519fb97f3382daa3e096a752515c3075b654
-      type: ssh
-      path: "/"
-    pupmod-simp-mcafee:
-      ref: eb65517bf77231e143b2cd467e4a248159ef72a6
-      type: ssh
-      path: "/"
-    pupmod-simp-mcollective:
-      ref: 3c8ca316af914a07898605aa74578a8ead9e0c98
-      type: ssh
-      path: "/"
-    puppet-memcached:
-      ref: 066dbbf7c2e50aaf37acdec765e4cc84eebe2ebd
-      type: ssh
-      path: "/"
-    pupmod-simp-mozilla:
-      ref: 0d69b8845fbbe736ee35ad0737ae4dc74b920729
-      type: ssh
-      path: "/"
-    pupmod-simp-multipathd:
-      ref: 4e406ac68f9ac28f305939fa83ef0846a0f07fa1
-      type: ssh
-      path: "/"
-    puppetlabs-mysql:
-      ref: 0701aa404ce36905426157b65472b0be243d2d24
-      type: ssh
-      path: "/"
-    pupmod-simp-named:
-      ref: 80e3c049ac8fc1a625bef3ec87884e1b7faa2f6a
-      type: ssh
-      path: "/"
-    pupmod-simp-network:
-      ref: 0d64e947f90c9fb1ea07e693f4620d78eba2d992
-      type: ssh
-      path: "/"
-    pupmod-simp-nfs:
-      ref: 14ac95db1561252a8d0c2487a10a06f629008d77
-      type: ssh
-      path: "/"
-    pupmod-simp-nscd:
-      ref: 348541f1dad0456bec66ff5fdab229d7ba968bc5
-      type: ssh
-      path: "/"
-    pupmod-simp-ntpd:
-      ref: f18b5b4f1c04e45591201d894d15c51b16f5989d
-      type: ssh
-      path: "/"
-    pupmod-simp-oddjob:
-      ref: 3ff2ab29202d5654209f31c61549e3e35ca42af0
-      type: ssh
-      path: "/"
-    pupmod-simp-openldap:
-      ref: 3cab9eae35e759cb33da998bc589e128efc8bfb5
-      type: ssh
-      path: "/"
-    pupmod-simp-openscap:
-      ref: 060721aaf97d5a1a63ff23b594b75bb820c604fc
-      type: ssh
-      path: "/"
-    pupmod-simp-pam:
-      ref: a8ad6a094281d7be11465132a0c51f77d11865e0
-      type: ssh
-      path: "/"
-    pupmod-simp-pki:
-      ref: 1afafc2d063ae0b7f3e69f19649913665a5a7326
-      type: ssh
-      path: "/"
-    pupmod-simp-polkit:
-      ref: 307b8c6937efea6a2ae5fdaadd28f575d1664229
-      type: ssh
-      path: "/"
-    pupmod-simp-postfix:
-      ref: e4a440fd0cddd4f3f891e0aa1ff73aced6a20d87
-      type: ssh
-      path: "/"
-    puppetlabs-postgresql:
-      ref: 06b31e750349b884ef6221b37fdb77c5e8093142
-      type: ssh
-      path: "/"
-    pupmod-simp-pupmod:
-      ref: d1caebf1195055740a43a725a0966371cb8a1902
-      type: ssh
-      path: "/"
-    puppetlabs-puppetdb:
-      ref: 2fdaacaf0ef575a635f78f8b9bdfb606cb36213f
-      type: ssh
-      path: "/"
-    puppetlabs-apache:
-      ref: 8c2a381b9e70b8093c18e4225e393edc1f63f489
-      type: ssh
-      path: "/"
-    pupmod-simp-rsync:
-      ref: fa1b1af84f4a6041735fef202b002647504f3c2f
-      type: ssh
-      path: "/"
-    pupmod-simp-rsyslog:
-      ref: 3f95cceb05e091e81662bd128766ace01c6063c4
-      type: ssh
-      path: "/"
-    pupmod-simp-selinux:
-      ref: cb9c080b1c9ed9a69c4fffa195cf12314405fd09
-      type: ssh
-      path: "/"
-    pupmod-simp-simp:
-      ref: 75478d194e6837ab62c39629a5e1d74981e17cfe
-      type: ssh
-      path: "/"
-    pupmod-simp-simplib:
-      ref: 7409ed3f70a82eb903834f713783612c84a24622
-      type: ssh
-      path: "/"
-    pupmod-simp-site:
-      ref: 151404c332df081cbdb3c048b59dc47004492855
-      type: ssh
-      path: "/"
-    pupmod-simp-snmpd:
-      ref: 79e754567920cf1f880f15b785e588685c921913
-      type: ssh
-      path: "/"
-    pupmod-simp-ssh:
-      ref: 7feb682fd913475937f1b523c9d5f9fc9ca9e2d8
-      type: ssh
-      path: "/"
-    pupmod-simp-sssd:
-      ref: '054658fac130254c624c12f1c6c06fd45f2623d2'
-      type: ssh
-      path: "/"
-    puppetlabs-stdlib:
-      ref: 7904016024f78769c9ca805380c81ed5134d3bd4
-      type: ssh
-      path: "/"
-    pupmod-simp-stunnel:
-      ref: 2ccfe97eb0c0e0d71ea79767cb05addff3b177f7
-      type: ssh
-      path: "/"
-    pupmod-simp-sudo:
-      ref: 676802b5493647ae3ef7c24316e2debdcf2338e3
-      type: ssh
-      path: "/"
-    pupmod-simp-sudosh:
-      ref: 7395e24ed6b35f3d6cddf8312957dffcad918c0c
-      type: ssh
-      path: "/"
-    pupmod-simp-svckill:
-      ref: edefa2cddba1ba4db479e7f57e2f74cab1c2f1d4
-      type: ssh
-      path: "/"
-    pupmod-simp-sysctl:
-      ref: 5bc5680d27e04a864612827dc1cb78117bfa8ef9
-      type: ssh
-      path: "/"
-    pupmod-simp-tcpwrappers:
-      ref: e36d6a3713e4a7ecc5fa80334fbc02ee4646cc95
-      type: ssh
-      path: "/"
-    pupmod-simp-tftpboot:
-      ref: 5cc58ef199fe284e1478be2ddf0218927c33ba72
-      type: ssh
-      path: "/"
-    pupmod-simp-tpm:
-      ref: 2848701c2ec65de1afd7e8ac613c26cb969a669a
-      type: ssh
-      path: "/"
-    pupmod-simp-upstart:
-      ref: 62fa6bb7c7a335c991669f9574398035bd37f500
-      type: ssh
-      path: "/"
-    pupmod-simp-vnc:
-      ref: af565396270d1d59c412cb171bdcfe4e76857e37
-      type: ssh
-      path: "/"
-    pupmod-simp-vsftpd:
-      ref: ba05bc981c0cf0420dd3ce0f8aea5b95a0e25d38
-      type: ssh
-      path: "/"
-    pupmod-simp-windowmanager:
-      ref: a7965043d6700620c421d57a440d37d5b4cc47bc
-      type: ssh
-      path: "/"
-    pupmod-simp-xinetd:
-      ref: 88cc3bc015f3de2296fce0d546d1b41963deca61
-      type: ssh
-      path: "/"
-    pupmod-simp-xwindows:
-      ref: 8422b708e231b1c8fae0c2f635249c8c1ef9dbbc
-      type: ssh
-      path: "/"
-    pupmod-compliance:
-      ref: 8f45fd473d810c84de1b86a7d8f3b6ac80df205a
-      type: https
-      path: "/"
+    components:
+      simp-doc:
+        ref: 5f2f6fb48e74006fb9cb3018624069287f8a526c
+        type: ssh
+        path: "/"
+      simp-rsync:
+        ref: 977e9eb575dc2a556fd3c0695f967b947252c180
+        type: ssh
+        path: "/"
+      rubygem-simp-cli:
+        ref: 97f01588c11ffd08a6660eb6d13dbcfb86688416
+        type: ssh
+        path: "/"
+      rubygem-simp-rake-helpers:
+        ref: 58ae09bd62e2c842e596f3f04c0486285818feb7
+        type: ssh
+        path: "/"
+      pupmod-simp-acpid:
+        ref: fede42bc5b2898418cde3a955f5c2457909be2a3
+        type: ssh
+        path: "/"
+      pupmod-simp-activemq:
+        ref: c8c1228313b1435e6de2a32dbfe813dac9cfcfac
+        type: ssh
+        path: "/"
+      pupmod-simp-aide:
+        ref: 6881ed821a39e5f455d49f7a19e0a03f23d2e674
+        type: ssh
+        path: "/"
+      pupmod-simp-apache:
+        ref: e581d98015ca6e2e47dacf3497d34f341ee6ab79
+        type: ssh
+        path: "/"
+      pupmod-simp-auditd:
+        ref: 6e53bf42173ac4b8a1e28b146347ba3cd11013e3
+        type: ssh
+        path: "/"
+      augeasproviders:
+        ref: 5813ab82ba9adc7272f1780b9bdb176ac50987aa
+        type: ssh
+        path: "/"
+      augeasproviders_apache:
+        ref: fd31e7332fc164e9ed14812531cc1bfd1fd0571e
+        type: ssh
+        path: "/"
+      augeasproviders_base:
+        ref: 5c38730f1099c823e45bf55434b37066ed981948
+        type: ssh
+        path: "/"
+      augeasproviders_core:
+        ref: 5ccde88a4e95de0b33bb7a9052aa0a7a63cde08f
+        type: ssh
+        path: "/"
+      augeasproviders_grub:
+        ref: fce9b2eabd3c1d3c9a09c4f1f5862ec11d4b06bb
+        type: ssh
+        path: "/"
+      augeasproviders_mounttab:
+        ref: e43627ba1dba50161117e5ab0ac203a05a90596c
+        type: ssh
+        path: "/"
+      augeasproviders_nagios:
+        ref: 2c7d49638ec39469a1003e7d325f7f38d6648d55
+        type: ssh
+        path: "/"
+      augeasproviders_pam:
+        ref: 3837cb601afaca5cae9be467a88d03289d1e61bd
+        type: ssh
+        path: "/"
+      augeasproviders_postgresql:
+        ref: 957bbdc5b5ca1a016c934c964420e32858b755a2
+        type: ssh
+        path: "/"
+      augeasproviders_puppet:
+        ref: 6e1582f3687fc99c773891a4a64935aa985c2004
+        type: ssh
+        path: "/"
+      augeasproviders_shellvar:
+        ref: d332a6de6b43ba3e5e64f1fa855eb4f5666042dc
+        type: ssh
+        path: "/"
+      augeasproviders_ssh:
+        ref: 79a33d5b8dcb0051006822ea8214c8b016ed0cf2
+        type: ssh
+        path: "/"
+      augeasproviders_sysctl:
+        ref: df7ce67de6bd3ee99c188e223c2e9c06d2b25877
+        type: ssh
+        path: "/"
+      pupmod-simp-autofs:
+        ref: 61224db6dac462966574869fc153c4530585c47b
+        type: ssh
+        path: "/"
+      pupmod-simp-backuppc:
+        ref: 7b58e2254dcfa277b84258966aa14ebff90e4458
+        type: ssh
+        path: "/"
+      pupmod-simp-cgroups:
+        ref: 2867cdb86cb6033345076e8733350ceac67ebe61
+        type: ssh
+        path: "/"
+      pupmod-simp-clamav:
+        ref: dcda570b4eafa2a512a2f5310c61f449193d835a
+        type: ssh
+        path: "/"
+      pupmod-simp-concat:
+        ref: 148e368649ca1f86b562392015c16d3a68e8ea39
+        type: ssh
+        path: "/"
+      puppet-datacat:
+        ref: 2a4d19093cce94c4ab75033ac5422458c3fc1c0c
+        type: ssh
+        path: "/"
+      pupmod-simp-dhcp:
+        ref: 31f355a175b562ba1e167779b193bf57785c78ff
+        type: ssh
+        path: "/"
+      puppet-elasticsearch:
+        ref: e923d23b77f79355ca615d605a9f4e94ac78a315
+        type: ssh
+        path: "/"
+      pupmod-simp-foreman:
+        ref: abecc39bfa1cf4526026414b4da2552b95ab5c50
+        type: ssh
+        path: "/"
+      pupmod-simp-freeradius:
+        ref: c7d369fc663f71fe8ac1260e7ccc53476d19f1eb
+        type: ssh
+        path: "/"
+      pupmod-simp-ganglia:
+        ref: da32cef6cd0768cc906dbc932bafd3d75b470013
+        type: ssh
+        path: "/"
+      pupmod-simp-gfs2:
+        ref: 9629c2905148a637a457d099d07af13c33cf981d
+        type: ssh
+        path: "/"
+      puppet-gpasswd:
+        ref: 68bc6fbb9d1b6e4cedbc84df2f40517819d14d28
+        type: ssh
+        path: "/"
+      puppetlabs-inifile:
+        ref: 821bad1cccfac9c9a46917d6b304d6a99878d60e
+        type: ssh
+        path: "/"
+      pupmod-simp-iptables:
+        ref: 893e645994108c18ed2d45fe295ce0d79e25def5
+        type: ssh
+        path: "/"
+      puppetlabs-java:
+        ref: d32802e712566abfcbe856479958f72c670891b9
+        type: ssh
+        path: "/"
+      puppetlabs-java_ks:
+        ref: 4ed1045f8aef04cbd86a74fa524c20c77e4a4caf
+        type: ssh
+        path: "/"
+      pupmod-simp-jenkins:
+        ref: 34a04976ea0ae4b00c5b732348c6ddec725a675c
+        type: ssh
+        path: "/"
+      pupmod-simp-kibana:
+        ref: 275ee292b2e9eda627b422e13fbdddbf262e1bc9
+        type: ssh
+        path: "/"
+      pupmod-simp-krb5:
+        ref: df44d53c3f0af7a1094ffc63e7cc1e365907fcd8
+        type: ssh
+        path: "/"
+      pupmod-simp-libvirt:
+        ref: c30b56e6d9394e867dd32371750543cf071d96db
+        type: ssh
+        path: "/"
+      pupmod-simp-logrotate:
+        ref: 077437dcd6f4c845af064885fb25dde95c843993
+        type: ssh
+        path: "/"
+      puppet-logstash:
+        ref: 9e95519fb97f3382daa3e096a752515c3075b654
+        type: ssh
+        path: "/"
+      pupmod-simp-mcafee:
+        ref: eb65517bf77231e143b2cd467e4a248159ef72a6
+        type: ssh
+        path: "/"
+      pupmod-simp-mcollective:
+        ref: 3c8ca316af914a07898605aa74578a8ead9e0c98
+        type: ssh
+        path: "/"
+      puppet-memcached:
+        ref: 066dbbf7c2e50aaf37acdec765e4cc84eebe2ebd
+        type: ssh
+        path: "/"
+      pupmod-simp-mozilla:
+        ref: 0d69b8845fbbe736ee35ad0737ae4dc74b920729
+        type: ssh
+        path: "/"
+      pupmod-simp-multipathd:
+        ref: 4e406ac68f9ac28f305939fa83ef0846a0f07fa1
+        type: ssh
+        path: "/"
+      puppetlabs-mysql:
+        ref: 0701aa404ce36905426157b65472b0be243d2d24
+        type: ssh
+        path: "/"
+      pupmod-simp-named:
+        ref: 80e3c049ac8fc1a625bef3ec87884e1b7faa2f6a
+        type: ssh
+        path: "/"
+      pupmod-simp-network:
+        ref: 0d64e947f90c9fb1ea07e693f4620d78eba2d992
+        type: ssh
+        path: "/"
+      pupmod-simp-nfs:
+        ref: 14ac95db1561252a8d0c2487a10a06f629008d77
+        type: ssh
+        path: "/"
+      pupmod-simp-nscd:
+        ref: 348541f1dad0456bec66ff5fdab229d7ba968bc5
+        type: ssh
+        path: "/"
+      pupmod-simp-ntpd:
+        ref: f18b5b4f1c04e45591201d894d15c51b16f5989d
+        type: ssh
+        path: "/"
+      pupmod-simp-oddjob:
+        ref: 3ff2ab29202d5654209f31c61549e3e35ca42af0
+        type: ssh
+        path: "/"
+      pupmod-simp-openldap:
+        ref: 3cab9eae35e759cb33da998bc589e128efc8bfb5
+        type: ssh
+        path: "/"
+      pupmod-simp-openscap:
+        ref: 060721aaf97d5a1a63ff23b594b75bb820c604fc
+        type: ssh
+        path: "/"
+      pupmod-simp-pam:
+        ref: a8ad6a094281d7be11465132a0c51f77d11865e0
+        type: ssh
+        path: "/"
+      pupmod-simp-pki:
+        ref: 1afafc2d063ae0b7f3e69f19649913665a5a7326
+        type: ssh
+        path: "/"
+      pupmod-simp-polkit:
+        ref: 307b8c6937efea6a2ae5fdaadd28f575d1664229
+        type: ssh
+        path: "/"
+      pupmod-simp-postfix:
+        ref: e4a440fd0cddd4f3f891e0aa1ff73aced6a20d87
+        type: ssh
+        path: "/"
+      puppetlabs-postgresql:
+        ref: 06b31e750349b884ef6221b37fdb77c5e8093142
+        type: ssh
+        path: "/"
+      pupmod-simp-pupmod:
+        ref: d1caebf1195055740a43a725a0966371cb8a1902
+        type: ssh
+        path: "/"
+      puppetlabs-puppetdb:
+        ref: 2fdaacaf0ef575a635f78f8b9bdfb606cb36213f
+        type: ssh
+        path: "/"
+      puppetlabs-apache:
+        ref: 8c2a381b9e70b8093c18e4225e393edc1f63f489
+        type: ssh
+        path: "/"
+      pupmod-simp-rsync:
+        ref: fa1b1af84f4a6041735fef202b002647504f3c2f
+        type: ssh
+        path: "/"
+      pupmod-simp-rsyslog:
+        ref: 3f95cceb05e091e81662bd128766ace01c6063c4
+        type: ssh
+        path: "/"
+      pupmod-simp-selinux:
+        ref: cb9c080b1c9ed9a69c4fffa195cf12314405fd09
+        type: ssh
+        path: "/"
+      pupmod-simp-simp:
+        ref: 75478d194e6837ab62c39629a5e1d74981e17cfe
+        type: ssh
+        path: "/"
+      pupmod-simp-simplib:
+        ref: 7409ed3f70a82eb903834f713783612c84a24622
+        type: ssh
+        path: "/"
+      pupmod-simp-site:
+        ref: 151404c332df081cbdb3c048b59dc47004492855
+        type: ssh
+        path: "/"
+      pupmod-simp-snmpd:
+        ref: 79e754567920cf1f880f15b785e588685c921913
+        type: ssh
+        path: "/"
+      pupmod-simp-ssh:
+        ref: 7feb682fd913475937f1b523c9d5f9fc9ca9e2d8
+        type: ssh
+        path: "/"
+      pupmod-simp-sssd:
+        ref: '054658fac130254c624c12f1c6c06fd45f2623d2'
+        type: ssh
+        path: "/"
+      puppetlabs-stdlib:
+        ref: 7904016024f78769c9ca805380c81ed5134d3bd4
+        type: ssh
+        path: "/"
+      pupmod-simp-stunnel:
+        ref: 2ccfe97eb0c0e0d71ea79767cb05addff3b177f7
+        type: ssh
+        path: "/"
+      pupmod-simp-sudo:
+        ref: 676802b5493647ae3ef7c24316e2debdcf2338e3
+        type: ssh
+        path: "/"
+      pupmod-simp-sudosh:
+        ref: 7395e24ed6b35f3d6cddf8312957dffcad918c0c
+        type: ssh
+        path: "/"
+      pupmod-simp-svckill:
+        ref: edefa2cddba1ba4db479e7f57e2f74cab1c2f1d4
+        type: ssh
+        path: "/"
+      pupmod-simp-sysctl:
+        ref: 5bc5680d27e04a864612827dc1cb78117bfa8ef9
+        type: ssh
+        path: "/"
+      pupmod-simp-tcpwrappers:
+        ref: e36d6a3713e4a7ecc5fa80334fbc02ee4646cc95
+        type: ssh
+        path: "/"
+      pupmod-simp-tftpboot:
+        ref: 5cc58ef199fe284e1478be2ddf0218927c33ba72
+        type: ssh
+        path: "/"
+      pupmod-simp-tpm:
+        ref: 2848701c2ec65de1afd7e8ac613c26cb969a669a
+        type: ssh
+        path: "/"
+      pupmod-simp-upstart:
+        ref: 62fa6bb7c7a335c991669f9574398035bd37f500
+        type: ssh
+        path: "/"
+      pupmod-simp-vnc:
+        ref: af565396270d1d59c412cb171bdcfe4e76857e37
+        type: ssh
+        path: "/"
+      pupmod-simp-vsftpd:
+        ref: ba05bc981c0cf0420dd3ce0f8aea5b95a0e25d38
+        type: ssh
+        path: "/"
+      pupmod-simp-windowmanager:
+        ref: a7965043d6700620c421d57a440d37d5b4cc47bc
+        type: ssh
+        path: "/"
+      pupmod-simp-xinetd:
+        ref: 88cc3bc015f3de2296fce0d546d1b41963deca61
+        type: ssh
+        path: "/"
+      pupmod-simp-xwindows:
+        ref: 8422b708e231b1c8fae0c2f635249c8c1ef9dbbc
+        type: ssh
+        path: "/"
+      pupmod-compliance:
+        ref: 8f45fd473d810c84de1b86a7d8f3b6ac80df205a
+        type: https
+        path: "/"
+    platforms:
+      CentOS-6.7-x86_64:
+      RedHat-6.7-x86_64:

--- a/v1/releases/4.3.0-0.yaml
+++ b/v1/releases/4.3.0-0.yaml
@@ -1,387 +1,391 @@
 ---
 releases:
   4.3.0-0:
-    simp-doc:
-      ref: 2487fe946410fb4b428796d2376f7c1b8e344e60
-      type: https
-      path: "/src"
-    simp-rsync:
-      ref: 977e9eb575dc2a556fd3c0695f967b947252c180
-      type: https
-      path: "/src"
-    rubygem-simp-cli:
-      ref: abc20ee23740cbb235875d18c4221c940d51b9c7
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: b63c0bd130897256f645d80af2bb958d2fd5448e
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: d02c78b014be9310eabbbb7d8267475efcf70e07
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: 9263e36c1803f9f83b6eb5e5ca3ff9b4f8cd0522
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: 89684597706048ae9df4bd2567d6be13682f9795
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: 934f915f85080b809900453868e8440444c9d4c3
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: 5e30c901f8358156873d7098c609f60697fb5ee5
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: bebe87262e32c7a2606f0d4b4e1200921730a105
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: 48c30bcaf453da36281104b5387d4a6ba44bbf93
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: 5cbcbbc2f185954edea1a63b29c6684d687e484e
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: 82dbe6518159e080f865425da3daa250305dd26a
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: e666487674fc98ae0c530686f819174179ffe046
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: 4b5b5f7e6c2c86ef7f924ac92b92e0d32f669e63
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: a9b2991447d1305d8d4fc1e98b4c1d1e06750566
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: 91a256e8aab5a76df07144fcff1e54ac9af7a815
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: ea5e3357ef5f2abf3eaa998fd39c6c61ded807ba
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: f235c7b032a6abca5b73687221a8fdf8f151691a
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: 48b6bbc2e86c79670f5057813d70c3ba60789fd0
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: 44154f381f7d3e692dae93b5bf05d4c1d9563217
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: 625ce220bae00f1c37415d9fdacc44c7c02d65b3
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: b4478aba815d5e7e9a9f82ca0f59533e312bf954
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: ebaf91499f75db3df60bd432561a9adc093bc999
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: 565bb7339e9fc0831d14545a9d2262d922878848
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 5a02c573242171c8d8210607fb19c766b2c4632f
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: 2da631be16147f153b7d0d3c52014d474e93e619
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: 810eb3f6b8d69726a7bd2db78088703dfa81d547
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: e0bd50b92d9b85effacce3a40e4b0ca1b8c1fc3b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: be08dac7e0d7cfed0441ca523383563592243c12
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: d9acbefb998777bc47a59c1f2484c1529bc553a7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: 7f6fbc1faf8e9bc8830d6a529af444dc9b2d2302
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: 955b492aa7563e72ab896b4e4800f633a759608f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-backuppc:
-      ref: 508604f43ba12149b3c57f269c2136ea744e4ce6
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-cgroups:
-      ref: c84b016b6a892c1122565dff0887973f383d5e52
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: 5446e05d9905e80a4511fb06c6175786593bb157
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-concat:
-      ref: 72421a7c67788cbd17b1efa0508741c6b0c2a8b8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: 7e0f9dc0b5e1114ab39efca1ee082f138226c7cb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-foreman:
-      ref: a42210f237d7e68af1a740a46d38119cd13ff6e8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: d6e0e3bc28742f58f15b3276d972529dd5db76e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ganglia:
-      ref: 70323b955b4233cdab40a34a6c6ac89397271dc5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-gfs2:
-      ref: 55afa387f1e721922f6abf89b0bccd6358346feb
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: 8610ae8b38b25e2c2bf502d6a82064915a4240e4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: 2424e13d7cd62b6679f4d3d8617ecacec841e8ae
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: a2cd576f707416128fb6c4e15dbd2a485941b43b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 783a7562d755e5e29fc2e5d4c8afd7fdd7e44b77
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: '02826504bb2babe2b37063cc937cad3c59013bde'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: 7bf9e44d055fc4ac9f81a601098b6209ffad3d80
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: 31386d5c602064e411769ef10288a729e20a185b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: c5f52de139d66361852f86ac3e13f7b490cbf14b
-      type: https
-      path: "/src/puppet/modules"
-    puppet-memcached:
-      ref: 2b4d56f0739fbcc6f01362ff846f0e7c7a8fb8b2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: 8ef627aad451d2d51a2b249ae21dbc2ba349098f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-multipathd:
-      ref: a2f37861fd3abd1efe1e9396ee9e18f1abde7135
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: 115bfae2a34cb97cd4f93f032068932587372e29
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 950edad163869ec894710f26f208b74e67828e8e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 243361d38726fdfea26ee3a349009b6d75aa2e21
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nscd:
-      ref: b3010a717cf8d4706b0c24782acf36fd8b2726af
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: 34f76d9e0e585b20de83b2f46f7c1337d8b5e748
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 8c7cc73766936278e3f97ecb90525ce0307e20ee
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openldap:
-      ref: 9847a8f30a6bffef6db2afa92dc71bf6d1abd409
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: 4a44514a30f47fa5ac36e77bc480b053731278cf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: 152871b905e78ee15951109a8d358241c28c0dc8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: 68fc208331e8f52da068eb77df882972bc801d46
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 4bd15a6c82cbb3f92daa77c2ab78c558c5768e26
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: 5a5480fb20fa5603958c3b65e8dffc02a6ea9f02
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: f2262a546365a96051ab27434ae69c7386ac6c0e
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 92dd2a464fa64eb802735f32b4cca6771fee48d7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsync:
-      ref: 8dcf5878387311664c49349f18b161eb67229dae
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: 4b7849e1de7d92deb6c9575b0ccd44b584d02829
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: 662b3220db3e885c87c75b41854083a447f78055
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: 4b9e53ae884a39296b21482ccf3db066f8df6278
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: ee7a6797f11b9dff18f7d0150e571ab95461a58d
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: a384a87dcc79bfc2cf9fbf754756fb38198cc44f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: 170b8590309ee358577a6ff24fb23829a06c680e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: aba8d486d8fa23a6903d6c327e55f6b48b68cb12
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 276e372aee1dc5b9cc70d6f1d0e697aeb05b9b16
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-snmpd:
-      ref: 4e6378976c24a387c66bf948f3c32b634c11d2ac
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: 533f5f383d5adeed143de938aa21b271c07a87cd
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: 22d0a4f96eb6369cee62808197c327f16dbd7cbf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 25884a2df15a7e307d4ebc307709a5eecc7d1e38
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: 4087d1f101f1bc4f6c315711466406321af969be
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: a8cab11c5aff8eaf0e2468518d72fb107a6c26a0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: b64aa7bc38402a44922c56508c0d9cbd42d11f94
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sysctl:
-      ref: fd7fee7000de3cb8436aad81d3ec91610b804c88
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: 18cd645cec646b67b7dfd3e21d3a677861680a64
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: 296b23bc4697a1aa5a53d72bccceef5d794a0b79
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 9f0d2e6f2c12c3cdcaf50dd19d8a7bea28c7899b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: f021e87802603c0474e5b990e345d9c8c67d42e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 631acad574a928eacc83a6fc85dd249f8a12eab3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: 07ecc2acc92d99429607771854701680c61e3cdc
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-windowmanager:
-      ref: 2c3ab26ed74ff5174addf402c3549e40134fec46
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: c92b0b6e86c59b7d30cca114326b6984b53d1ed8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xwindows:
-      ref: f4eebdb1f1d8874a5db59b9193dcd5dfda27c7e2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: cfed507b768bdcced60d3091e0d54d673b27763d
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 2487fe946410fb4b428796d2376f7c1b8e344e60
+        type: https
+        path: "/src"
+      simp-rsync:
+        ref: 977e9eb575dc2a556fd3c0695f967b947252c180
+        type: https
+        path: "/src"
+      rubygem-simp-cli:
+        ref: abc20ee23740cbb235875d18c4221c940d51b9c7
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: b63c0bd130897256f645d80af2bb958d2fd5448e
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: d02c78b014be9310eabbbb7d8267475efcf70e07
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: 9263e36c1803f9f83b6eb5e5ca3ff9b4f8cd0522
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: 89684597706048ae9df4bd2567d6be13682f9795
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: 934f915f85080b809900453868e8440444c9d4c3
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: 5e30c901f8358156873d7098c609f60697fb5ee5
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: bebe87262e32c7a2606f0d4b4e1200921730a105
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: 48c30bcaf453da36281104b5387d4a6ba44bbf93
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: 5cbcbbc2f185954edea1a63b29c6684d687e484e
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: 82dbe6518159e080f865425da3daa250305dd26a
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: e666487674fc98ae0c530686f819174179ffe046
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: 4b5b5f7e6c2c86ef7f924ac92b92e0d32f669e63
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: a9b2991447d1305d8d4fc1e98b4c1d1e06750566
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: 91a256e8aab5a76df07144fcff1e54ac9af7a815
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: ea5e3357ef5f2abf3eaa998fd39c6c61ded807ba
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: f235c7b032a6abca5b73687221a8fdf8f151691a
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: 48b6bbc2e86c79670f5057813d70c3ba60789fd0
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: 44154f381f7d3e692dae93b5bf05d4c1d9563217
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: 625ce220bae00f1c37415d9fdacc44c7c02d65b3
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: b4478aba815d5e7e9a9f82ca0f59533e312bf954
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: ebaf91499f75db3df60bd432561a9adc093bc999
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: 565bb7339e9fc0831d14545a9d2262d922878848
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 5a02c573242171c8d8210607fb19c766b2c4632f
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: 2da631be16147f153b7d0d3c52014d474e93e619
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: 810eb3f6b8d69726a7bd2db78088703dfa81d547
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: e0bd50b92d9b85effacce3a40e4b0ca1b8c1fc3b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: be08dac7e0d7cfed0441ca523383563592243c12
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: d9acbefb998777bc47a59c1f2484c1529bc553a7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: 7f6fbc1faf8e9bc8830d6a529af444dc9b2d2302
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: 955b492aa7563e72ab896b4e4800f633a759608f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-backuppc:
+        ref: 508604f43ba12149b3c57f269c2136ea744e4ce6
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-cgroups:
+        ref: c84b016b6a892c1122565dff0887973f383d5e52
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: 5446e05d9905e80a4511fb06c6175786593bb157
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-concat:
+        ref: 72421a7c67788cbd17b1efa0508741c6b0c2a8b8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: 7e0f9dc0b5e1114ab39efca1ee082f138226c7cb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-foreman:
+        ref: a42210f237d7e68af1a740a46d38119cd13ff6e8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: d6e0e3bc28742f58f15b3276d972529dd5db76e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ganglia:
+        ref: 70323b955b4233cdab40a34a6c6ac89397271dc5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-gfs2:
+        ref: 55afa387f1e721922f6abf89b0bccd6358346feb
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: 8610ae8b38b25e2c2bf502d6a82064915a4240e4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: 2424e13d7cd62b6679f4d3d8617ecacec841e8ae
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: a2cd576f707416128fb6c4e15dbd2a485941b43b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 783a7562d755e5e29fc2e5d4c8afd7fdd7e44b77
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: '02826504bb2babe2b37063cc937cad3c59013bde'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: 7bf9e44d055fc4ac9f81a601098b6209ffad3d80
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: 31386d5c602064e411769ef10288a729e20a185b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: c5f52de139d66361852f86ac3e13f7b490cbf14b
+        type: https
+        path: "/src/puppet/modules"
+      puppet-memcached:
+        ref: 2b4d56f0739fbcc6f01362ff846f0e7c7a8fb8b2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: 8ef627aad451d2d51a2b249ae21dbc2ba349098f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-multipathd:
+        ref: a2f37861fd3abd1efe1e9396ee9e18f1abde7135
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: 115bfae2a34cb97cd4f93f032068932587372e29
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 950edad163869ec894710f26f208b74e67828e8e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 243361d38726fdfea26ee3a349009b6d75aa2e21
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nscd:
+        ref: b3010a717cf8d4706b0c24782acf36fd8b2726af
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: 34f76d9e0e585b20de83b2f46f7c1337d8b5e748
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 8c7cc73766936278e3f97ecb90525ce0307e20ee
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openldap:
+        ref: 9847a8f30a6bffef6db2afa92dc71bf6d1abd409
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: 4a44514a30f47fa5ac36e77bc480b053731278cf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: 152871b905e78ee15951109a8d358241c28c0dc8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: 68fc208331e8f52da068eb77df882972bc801d46
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 4bd15a6c82cbb3f92daa77c2ab78c558c5768e26
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: 5a5480fb20fa5603958c3b65e8dffc02a6ea9f02
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: f2262a546365a96051ab27434ae69c7386ac6c0e
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 92dd2a464fa64eb802735f32b4cca6771fee48d7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsync:
+        ref: 8dcf5878387311664c49349f18b161eb67229dae
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: 4b7849e1de7d92deb6c9575b0ccd44b584d02829
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: 662b3220db3e885c87c75b41854083a447f78055
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: 4b9e53ae884a39296b21482ccf3db066f8df6278
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: ee7a6797f11b9dff18f7d0150e571ab95461a58d
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: a384a87dcc79bfc2cf9fbf754756fb38198cc44f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: 170b8590309ee358577a6ff24fb23829a06c680e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: aba8d486d8fa23a6903d6c327e55f6b48b68cb12
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 276e372aee1dc5b9cc70d6f1d0e697aeb05b9b16
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-snmpd:
+        ref: 4e6378976c24a387c66bf948f3c32b634c11d2ac
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: 533f5f383d5adeed143de938aa21b271c07a87cd
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: 22d0a4f96eb6369cee62808197c327f16dbd7cbf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 25884a2df15a7e307d4ebc307709a5eecc7d1e38
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: 4087d1f101f1bc4f6c315711466406321af969be
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: a8cab11c5aff8eaf0e2468518d72fb107a6c26a0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: b64aa7bc38402a44922c56508c0d9cbd42d11f94
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sysctl:
+        ref: fd7fee7000de3cb8436aad81d3ec91610b804c88
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: 18cd645cec646b67b7dfd3e21d3a677861680a64
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: 296b23bc4697a1aa5a53d72bccceef5d794a0b79
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 9f0d2e6f2c12c3cdcaf50dd19d8a7bea28c7899b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: f021e87802603c0474e5b990e345d9c8c67d42e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 631acad574a928eacc83a6fc85dd249f8a12eab3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: 07ecc2acc92d99429607771854701680c61e3cdc
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-windowmanager:
+        ref: 2c3ab26ed74ff5174addf402c3549e40134fec46
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: c92b0b6e86c59b7d30cca114326b6984b53d1ed8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xwindows:
+        ref: f4eebdb1f1d8874a5db59b9193dcd5dfda27c7e2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: cfed507b768bdcced60d3091e0d54d673b27763d
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-6.8-x86_64:
+      RedHat-6.8-x86_64:

--- a/v1/releases/4.3.1-0.yaml
+++ b/v1/releases/4.3.1-0.yaml
@@ -1,391 +1,395 @@
 ---
 releases:
   4.3.1-0:
-    simp-doc:
-      ref: 37dd99c99af38e7fb40a34d0b1b699fcadaee726
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: 72de5f3d840b56035c729b41cdbb218136f0673c
-      type: https
-      path: "/src/puppet/modules"
-    rubygem-simp-cli:
-      ref: 865e88acb9a457362065dff80e3d73d6e4024386
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: a78bb99b3433205ada75febcf4a91b510caa9ce4
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: 61a9d3d83c184bda7e935154fcc295e40bda924a
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: decefc4e2a36580a52818f72f0a054e0088a1b6e
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: 69b80fee1e1ae13a0e120c46155cad1cfbde70b9
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: 57e1671c51e44400d29d977d2381d30690c5d923
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: 9e8c99bc2298e4da3961474d3f4e07f2037ae8dd
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: ee2147a12008f4ef20a40f0f366064b86b5a7f65
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: 16858eb5b4370e3242b4b153af597fa5cbe3b75d
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: 4abc6ea682e9bb8e4a5d8b781ded33e601e11003
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: 3e54f665cb6b2e18c603bb3697d21c6bd6141e59
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: 7e58204da822597614e3440505e61a8e24af532a
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: 259c80fb874c749ec4bf6ecbb81b53ff7765689c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: 544577195bbe4b3b9e14c3b97daec2cb527b2ada
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: 983ad018810381d6cc7b523dd09813d1d5c36227
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: 203f848a6373a3ca5d9f1744d7f616fbb1212bc3
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: f8d932d07acb8a3004ba83ed7a34fbafa2a19a0e
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: 71294cf36bd80d26cfdfd7608c18e543c0d96298
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: 32b9809a198a732b1d80d5a53c9187b9f77a84b3
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: 6efaf0babec70adb2c3422660c313870ec17f04b
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: 54728003a07b74f39964eb6c56e92cf071b6d8f1
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: '078c99bdb1e26a4081b58298abf153ba25d52800'
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: 0ecc08653d9bf51fe9096a6321926f9c8cc38ab1
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: 70ac888d8df727267e9e159b3c18e2e1b2a0e202
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 300ea24e7b9102c6d14424bed1fe3c4d5fc08057
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: e33d7b96ffe4121e0fd0297f51e6a8981549b6ed
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: 86c1e5bc2cf95babd04a37777997a00156f8dc0f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: e6c3b06b661ae26dd3215fdc8d82904115c25e2c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: bb6307f7b4fb0e283fb89146ee0e50385666c733
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: 6b85606df3bd1d3943c3d2c85e6d01e5deaa9ce3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: 21a7b59b110f61b731eb3fe6c773ffe569d0054a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: f8246519048d62928f68cc97bce5c5fa86d4b5aa
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-backuppc:
-      ref: 4654856c7713bcdb27b188c199c8dc647470ea6b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-cgroups:
-      ref: c84b016b6a892c1122565dff0887973f383d5e52
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: a7dde5af88f40d25ea3de94605ae8885c0e11303
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-concat:
-      ref: 747f4e02713b32c3032d57b24f57a4c690a37e3c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: e080364fc93be0d18538844d6aca6110aea7427e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dirtycow:
-      ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-foreman:
-      ref: c1ee8d60797430fbf2cc6c296523c6e34fd3a522
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: a4093c8c8984f9072bbcf51c2c4fc0ac5e52048e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ganglia:
-      ref: b5e2606246bbae322a2a2efcee7d699833cd089f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-gfs2:
-      ref: 1c5118710aa8f85c3909a3178efceb9faca0235b
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: 8e102613db7181fde39b54481bc17a1640abf504
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: d6594ff6bb3de07a222684ead202049bebe44a3e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: 400d8dddb3b41262a682f9ebfd7fb694593ce2b0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 79d504724035b9d90891083943d8bc768a59e335
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libreswan:
-      ref: 6ed2c808b91205866b8689d876dbffb02c634eb2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: df2ae56a7ddb26fb3298129057c1ab5b9a734467
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: c9beaa857ccc1ba574fe9776cfb633d0afeb47a1
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: 4cfd91158d36c64ce3bcc41d6149ea7cf7cddb54
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: eae813299ba133c7dd87daf34cf650747f5303a0
-      type: https
-      path: "/src/puppet/modules"
-    puppet-memcached:
-      ref: 2b4d56f0739fbcc6f01362ff846f0e7c7a8fb8b2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: 22e6f560de43536b366423c4df6da8e671cfb418
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-multipathd:
-      ref: a2f37861fd3abd1efe1e9396ee9e18f1abde7135
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: 311374cc39d79645cf6b087575b30fea6751c089
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 07adaa8e15ce55c7fa29b76152cd0d10ecbd6103
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 6055a1ee3222f2a74d854c587f678d55d0a2c7b7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nscd:
-      ref: c574fe6a45a7589a78da4d12291753614c955fa5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: 3ca80d08c1ad800a20ca8fb5aa29a756d51db3ec
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 1f2ccc4ba474fe68dc815f4df9bdf5547c7a2355
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openldap:
-      ref: 89036f7e182de073cbba13834a58fa569b6589c4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: 794f4a6c733faa5bbb646fe9349cb5199cdacc7e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: ae14c45acb3b849b5a44bd9eb7c7729afaf0330a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: eeda24b447b2ef3ede8347f6f891e82bc40482e7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 0f2099180fc7688afaafe7b67ce4e65da1c714ae
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: c8eaec5efdd53c421718e6b76b82bb9d5a4596c8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: fc907515d15beadd08bb2d979db83942fa51d11a
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 353e735893b6bcf1d6833e2a82dfcd6c511535d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: 6cac3218633a01e14d18e365b31fb0aa11363ce4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: d4c4e8b07a2a65f0b1f927231d7b7a2c084474b3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: e3c8a7b649ae717a63035dddbda77abf5d3d5f90
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: d3f7900abe840b34049af476fa9997d9cc4e39e2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: be45b100650ffcabcf9213bab095f54474a157c9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: 977e6e144db50ec60d5dd98a10d190f6189a4582
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: b638d890f1c3b685a75668b046efe0c0e8190596
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 42ac183186ac30031685ab49fa94d0abf98d5dad
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-snmpd:
-      ref: fe37cf8cdea4b9e7e5c321b4cccdcbc98cd141d2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: 0342da0d9cf9fe9df5c1c9445204635148867db8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: 4d912229a22cd8a2d1b751c53f12b03aace162fe
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 56246194b25e6369b9ecf59f1738c0837b238e36
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: 2f086f13dd9231dd9666351b3683b17e595dec52
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: 0c3599ca9709b770178f32b0b57b252018fc65fe
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: 31b86e74cdfee1fceb46356b0e0c8cfbfbf43326
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sysctl:
-      ref: 6be0196003fdb201d04460b3e20156a978f80fa4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: 7ca8448bb0c8d36e923e2fdceb84a7a4f0aff2c9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: 479dccf64719153ec9e6ea9924860686dc5921c4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 36a43b474f9a5f8d7b2f72469d1d19bf9e7f5baf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: ce7d96ef122f7d0081509b2b8b81ab1dda541760
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 0d5cbbd41c40b7b783a12fc6be9c50da1594e20b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: 2ec702899c9e55f07b52dffd7b00304e34894608
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-windowmanager:
-      ref: ab889b380396330b6e2608b8aefbda10f3b88816
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: 4b65dd0dec18f12f9f4b902a229cd7b135d1db79
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xwindows:
-      ref: 0c5377cdcbad046653a532d867f230f3042260a3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: 3b746f000fe3c756b1d871c4d6b25583c705bfdb
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 37dd99c99af38e7fb40a34d0b1b699fcadaee726
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: 72de5f3d840b56035c729b41cdbb218136f0673c
+        type: https
+        path: "/src/puppet/modules"
+      rubygem-simp-cli:
+        ref: 865e88acb9a457362065dff80e3d73d6e4024386
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: a78bb99b3433205ada75febcf4a91b510caa9ce4
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: 61a9d3d83c184bda7e935154fcc295e40bda924a
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: decefc4e2a36580a52818f72f0a054e0088a1b6e
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: 69b80fee1e1ae13a0e120c46155cad1cfbde70b9
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: 57e1671c51e44400d29d977d2381d30690c5d923
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: 9e8c99bc2298e4da3961474d3f4e07f2037ae8dd
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: ee2147a12008f4ef20a40f0f366064b86b5a7f65
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: 16858eb5b4370e3242b4b153af597fa5cbe3b75d
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: 4abc6ea682e9bb8e4a5d8b781ded33e601e11003
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: 3e54f665cb6b2e18c603bb3697d21c6bd6141e59
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: 7e58204da822597614e3440505e61a8e24af532a
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: 259c80fb874c749ec4bf6ecbb81b53ff7765689c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: 544577195bbe4b3b9e14c3b97daec2cb527b2ada
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: 983ad018810381d6cc7b523dd09813d1d5c36227
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: 203f848a6373a3ca5d9f1744d7f616fbb1212bc3
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: f8d932d07acb8a3004ba83ed7a34fbafa2a19a0e
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: 71294cf36bd80d26cfdfd7608c18e543c0d96298
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: 32b9809a198a732b1d80d5a53c9187b9f77a84b3
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: 6efaf0babec70adb2c3422660c313870ec17f04b
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: 54728003a07b74f39964eb6c56e92cf071b6d8f1
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: '078c99bdb1e26a4081b58298abf153ba25d52800'
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: 0ecc08653d9bf51fe9096a6321926f9c8cc38ab1
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: 70ac888d8df727267e9e159b3c18e2e1b2a0e202
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 300ea24e7b9102c6d14424bed1fe3c4d5fc08057
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: e33d7b96ffe4121e0fd0297f51e6a8981549b6ed
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: 86c1e5bc2cf95babd04a37777997a00156f8dc0f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: e6c3b06b661ae26dd3215fdc8d82904115c25e2c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: bb6307f7b4fb0e283fb89146ee0e50385666c733
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: 6b85606df3bd1d3943c3d2c85e6d01e5deaa9ce3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: 21a7b59b110f61b731eb3fe6c773ffe569d0054a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: f8246519048d62928f68cc97bce5c5fa86d4b5aa
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-backuppc:
+        ref: 4654856c7713bcdb27b188c199c8dc647470ea6b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-cgroups:
+        ref: c84b016b6a892c1122565dff0887973f383d5e52
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: a7dde5af88f40d25ea3de94605ae8885c0e11303
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-concat:
+        ref: 747f4e02713b32c3032d57b24f57a4c690a37e3c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: e080364fc93be0d18538844d6aca6110aea7427e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dirtycow:
+        ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-foreman:
+        ref: c1ee8d60797430fbf2cc6c296523c6e34fd3a522
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: a4093c8c8984f9072bbcf51c2c4fc0ac5e52048e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ganglia:
+        ref: b5e2606246bbae322a2a2efcee7d699833cd089f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-gfs2:
+        ref: 1c5118710aa8f85c3909a3178efceb9faca0235b
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: 8e102613db7181fde39b54481bc17a1640abf504
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: d6594ff6bb3de07a222684ead202049bebe44a3e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: 400d8dddb3b41262a682f9ebfd7fb694593ce2b0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 79d504724035b9d90891083943d8bc768a59e335
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libreswan:
+        ref: 6ed2c808b91205866b8689d876dbffb02c634eb2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: df2ae56a7ddb26fb3298129057c1ab5b9a734467
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: c9beaa857ccc1ba574fe9776cfb633d0afeb47a1
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: 4cfd91158d36c64ce3bcc41d6149ea7cf7cddb54
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: eae813299ba133c7dd87daf34cf650747f5303a0
+        type: https
+        path: "/src/puppet/modules"
+      puppet-memcached:
+        ref: 2b4d56f0739fbcc6f01362ff846f0e7c7a8fb8b2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: 22e6f560de43536b366423c4df6da8e671cfb418
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-multipathd:
+        ref: a2f37861fd3abd1efe1e9396ee9e18f1abde7135
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: 311374cc39d79645cf6b087575b30fea6751c089
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 07adaa8e15ce55c7fa29b76152cd0d10ecbd6103
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 6055a1ee3222f2a74d854c587f678d55d0a2c7b7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nscd:
+        ref: c574fe6a45a7589a78da4d12291753614c955fa5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: 3ca80d08c1ad800a20ca8fb5aa29a756d51db3ec
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 1f2ccc4ba474fe68dc815f4df9bdf5547c7a2355
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openldap:
+        ref: 89036f7e182de073cbba13834a58fa569b6589c4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: 794f4a6c733faa5bbb646fe9349cb5199cdacc7e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: ae14c45acb3b849b5a44bd9eb7c7729afaf0330a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: eeda24b447b2ef3ede8347f6f891e82bc40482e7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 0f2099180fc7688afaafe7b67ce4e65da1c714ae
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: c8eaec5efdd53c421718e6b76b82bb9d5a4596c8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: fc907515d15beadd08bb2d979db83942fa51d11a
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 353e735893b6bcf1d6833e2a82dfcd6c511535d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: 6cac3218633a01e14d18e365b31fb0aa11363ce4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: d4c4e8b07a2a65f0b1f927231d7b7a2c084474b3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: e3c8a7b649ae717a63035dddbda77abf5d3d5f90
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: d3f7900abe840b34049af476fa9997d9cc4e39e2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: be45b100650ffcabcf9213bab095f54474a157c9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: 977e6e144db50ec60d5dd98a10d190f6189a4582
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: b638d890f1c3b685a75668b046efe0c0e8190596
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 42ac183186ac30031685ab49fa94d0abf98d5dad
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-snmpd:
+        ref: fe37cf8cdea4b9e7e5c321b4cccdcbc98cd141d2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: 0342da0d9cf9fe9df5c1c9445204635148867db8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: 4d912229a22cd8a2d1b751c53f12b03aace162fe
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 56246194b25e6369b9ecf59f1738c0837b238e36
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: 2f086f13dd9231dd9666351b3683b17e595dec52
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: 0c3599ca9709b770178f32b0b57b252018fc65fe
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: 31b86e74cdfee1fceb46356b0e0c8cfbfbf43326
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sysctl:
+        ref: 6be0196003fdb201d04460b3e20156a978f80fa4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: 7ca8448bb0c8d36e923e2fdceb84a7a4f0aff2c9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: 479dccf64719153ec9e6ea9924860686dc5921c4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 36a43b474f9a5f8d7b2f72469d1d19bf9e7f5baf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: ce7d96ef122f7d0081509b2b8b81ab1dda541760
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 0d5cbbd41c40b7b783a12fc6be9c50da1594e20b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: 2ec702899c9e55f07b52dffd7b00304e34894608
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-windowmanager:
+        ref: ab889b380396330b6e2608b8aefbda10f3b88816
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: 4b65dd0dec18f12f9f4b902a229cd7b135d1db79
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xwindows:
+        ref: 0c5377cdcbad046653a532d867f230f3042260a3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: 3b746f000fe3c756b1d871c4d6b25583c705bfdb
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-6.8-x86_64:
+      RedHat-6.8-x86_64:

--- a/v1/releases/5.1.0-3.yaml
+++ b/v1/releases/5.1.0-3.yaml
@@ -1,343 +1,347 @@
 ---
 releases:
   5.1.0-3:
-    simp-doc:
-      ref: fb3ec26f55a2ae5c24fa614de5fd4188af69b718
-      type: https
-      path: "/"
-    simp-rsync:
-      ref: 1a1f54ebd4c8cdf39e651ff715cb761cc364047e
-      type: https
-      path: "/"
-    rubygem-simp-cli:
-      ref: 97f01588c11ffd08a6660eb6d13dbcfb86688416
-      type: https
-      path: "/"
-    rubygem-simp-rake-helpers:
-      ref: 58ae09bd62e2c842e596f3f04c0486285818feb7
-      type: https
-      path: "/"
-    pupmod-simp-acpid:
-      ref: fede42bc5b2898418cde3a955f5c2457909be2a3
-      type: https
-      path: "/"
-    pupmod-simp-activemq:
-      ref: c8c1228313b1435e6de2a32dbfe813dac9cfcfac
-      type: https
-      path: "/"
-    pupmod-simp-aide:
-      ref: 6881ed821a39e5f455d49f7a19e0a03f23d2e674
-      type: https
-      path: "/"
-    pupmod-simp-apache:
-      ref: e581d98015ca6e2e47dacf3497d34f341ee6ab79
-      type: https
-      path: "/"
-    pupmod-simp-auditd:
-      ref: 6e53bf42173ac4b8a1e28b146347ba3cd11013e3
-      type: https
-      path: "/"
-    augeasproviders:
-      ref: 5813ab82ba9adc7272f1780b9bdb176ac50987aa
-      type: https
-      path: "/"
-    augeasproviders_apache:
-      ref: fd31e7332fc164e9ed14812531cc1bfd1fd0571e
-      type: https
-      path: "/"
-    augeasproviders_base:
-      ref: 5c38730f1099c823e45bf55434b37066ed981948
-      type: https
-      path: "/"
-    augeasproviders_core:
-      ref: 5ccde88a4e95de0b33bb7a9052aa0a7a63cde08f
-      type: https
-      path: "/"
-    augeasproviders_grub:
-      ref: fce9b2eabd3c1d3c9a09c4f1f5862ec11d4b06bb
-      type: https
-      path: "/"
-    augeasproviders_mounttab:
-      ref: e43627ba1dba50161117e5ab0ac203a05a90596c
-      type: https
-      path: "/"
-    augeasproviders_nagios:
-      ref: 2c7d49638ec39469a1003e7d325f7f38d6648d55
-      type: https
-      path: "/"
-    augeasproviders_pam:
-      ref: 3837cb601afaca5cae9be467a88d03289d1e61bd
-      type: https
-      path: "/"
-    augeasproviders_postgresql:
-      ref: 957bbdc5b5ca1a016c934c964420e32858b755a2
-      type: https
-      path: "/"
-    augeasproviders_puppet:
-      ref: 6e1582f3687fc99c773891a4a64935aa985c2004
-      type: https
-      path: "/"
-    augeasproviders_shellvar:
-      ref: d332a6de6b43ba3e5e64f1fa855eb4f5666042dc
-      type: https
-      path: "/"
-    augeasproviders_ssh:
-      ref: 79a33d5b8dcb0051006822ea8214c8b016ed0cf2
-      type: https
-      path: "/"
-    augeasproviders_sysctl:
-      ref: df7ce67de6bd3ee99c188e223c2e9c06d2b25877
-      type: https
-      path: "/"
-    pupmod-simp-autofs:
-      ref: 61224db6dac462966574869fc153c4530585c47b
-      type: https
-      path: "/"
-    pupmod-simp-clamav:
-      ref: dcda570b4eafa2a512a2f5310c61f449193d835a
-      type: https
-      path: "/"
-    pupmod-simp-concat:
-      ref: 148e368649ca1f86b562392015c16d3a68e8ea39
-      type: https
-      path: "/"
-    puppet-datacat:
-      ref: 2a4d19093cce94c4ab75033ac5422458c3fc1c0c
-      type: https
-      path: "/"
-    pupmod-simp-dhcp:
-      ref: 31f355a175b562ba1e167779b193bf57785c78ff
-      type: https
-      path: "/"
-    puppet-elasticsearch:
-      ref: e923d23b77f79355ca615d605a9f4e94ac78a315
-      type: https
-      path: "/"
-    pupmod-simp-foreman:
-      ref: abecc39bfa1cf4526026414b4da2552b95ab5c50
-      type: https
-      path: "/"
-    pupmod-simp-freeradius:
-      ref: c7d369fc663f71fe8ac1260e7ccc53476d19f1eb
-      type: https
-      path: "/"
-    pupmod-simp-ganglia:
-      ref: da32cef6cd0768cc906dbc932bafd3d75b470013
-      type: https
-      path: "/"
-    puppet-gpasswd:
-      ref: 68bc6fbb9d1b6e4cedbc84df2f40517819d14d28
-      type: https
-      path: "/"
-    puppetlabs-inifile:
-      ref: 821bad1cccfac9c9a46917d6b304d6a99878d60e
-      type: https
-      path: "/"
-    pupmod-simp-iptables:
-      ref: 893e645994108c18ed2d45fe295ce0d79e25def5
-      type: https
-      path: "/"
-    puppetlabs-java:
-      ref: d32802e712566abfcbe856479958f72c670891b9
-      type: https
-      path: "/"
-    puppetlabs-java_ks:
-      ref: 4ed1045f8aef04cbd86a74fa524c20c77e4a4caf
-      type: https
-      path: "/"
-    pupmod-simp-kibana:
-      ref: 275ee292b2e9eda627b422e13fbdddbf262e1bc9
-      type: https
-      path: "/"
-    pupmod-simp-libvirt:
-      ref: c30b56e6d9394e867dd32371750543cf071d96db
-      type: https
-      path: "/"
-    pupmod-simp-logrotate:
-      ref: 077437dcd6f4c845af064885fb25dde95c843993
-      type: https
-      path: "/"
-    puppet-logstash:
-      ref: 9e95519fb97f3382daa3e096a752515c3075b654
-      type: https
-      path: "/"
-    pupmod-simp-mcafee:
-      ref: eb65517bf77231e143b2cd467e4a248159ef72a6
-      type: https
-      path: "/"
-    pupmod-simp-mcollective:
-      ref: 3c8ca316af914a07898605aa74578a8ead9e0c98
-      type: https
-      path: "/"
-    pupmod-simp-mozilla:
-      ref: 0d69b8845fbbe736ee35ad0737ae4dc74b920729
-      type: https
-      path: "/"
-    puppetlabs-mysql:
-      ref: 0701aa404ce36905426157b65472b0be243d2d24
-      type: https
-      path: "/"
-    pupmod-simp-named:
-      ref: 80e3c049ac8fc1a625bef3ec87884e1b7faa2f6a
-      type: https
-      path: "/"
-    pupmod-simp-network:
-      ref: 0d64e947f90c9fb1ea07e693f4620d78eba2d992
-      type: https
-      path: "/"
-    pupmod-simp-nfs:
-      ref: 14ac95db1561252a8d0c2487a10a06f629008d77
-      type: https
-      path: "/"
-    pupmod-simp-nscd:
-      ref: 348541f1dad0456bec66ff5fdab229d7ba968bc5
-      type: https
-      path: "/"
-    pupmod-simp-ntpd:
-      ref: f18b5b4f1c04e45591201d894d15c51b16f5989d
-      type: https
-      path: "/"
-    pupmod-simp-oddjob:
-      ref: 3ff2ab29202d5654209f31c61549e3e35ca42af0
-      type: https
-      path: "/"
-    pupmod-simp-openldap:
-      ref: 3cab9eae35e759cb33da998bc589e128efc8bfb5
-      type: https
-      path: "/"
-    pupmod-simp-openscap:
-      ref: 060721aaf97d5a1a63ff23b594b75bb820c604fc
-      type: https
-      path: "/"
-    pupmod-simp-pam:
-      ref: a8ad6a094281d7be11465132a0c51f77d11865e0
-      type: https
-      path: "/"
-    pupmod-simp-pki:
-      ref: 1afafc2d063ae0b7f3e69f19649913665a5a7326
-      type: https
-      path: "/"
-    pupmod-simp-polkit:
-      ref: 307b8c6937efea6a2ae5fdaadd28f575d1664229
-      type: https
-      path: "/"
-    pupmod-simp-postfix:
-      ref: e4a440fd0cddd4f3f891e0aa1ff73aced6a20d87
-      type: https
-      path: "/"
-    puppetlabs-postgresql:
-      ref: 06b31e750349b884ef6221b37fdb77c5e8093142
-      type: https
-      path: "/"
-    pupmod-simp-pupmod:
-      ref: d1caebf1195055740a43a725a0966371cb8a1902
-      type: https
-      path: "/"
-    puppetlabs-puppetdb:
-      ref: 2fdaacaf0ef575a635f78f8b9bdfb606cb36213f
-      type: https
-      path: "/"
-    puppetlabs-apache:
-      ref: 8c2a381b9e70b8093c18e4225e393edc1f63f489
-      type: https
-      path: "/"
-    pupmod-simp-rsync:
-      ref: fa1b1af84f4a6041735fef202b002647504f3c2f
-      type: https
-      path: "/"
-    pupmod-simp-rsyslog:
-      ref: 3f95cceb05e091e81662bd128766ace01c6063c4
-      type: https
-      path: "/"
-    pupmod-simp-selinux:
-      ref: cb9c080b1c9ed9a69c4fffa195cf12314405fd09
-      type: https
-      path: "/"
-    pupmod-simp-simp:
-      ref: 75478d194e6837ab62c39629a5e1d74981e17cfe
-      type: https
-      path: "/"
-    pupmod-simp-simplib:
-      ref: 7409ed3f70a82eb903834f713783612c84a24622
-      type: https
-      path: "/"
-    pupmod-simp-site:
-      ref: 151404c332df081cbdb3c048b59dc47004492855
-      type: https
-      path: "/"
-    pupmod-simp-snmpd:
-      ref: 79e754567920cf1f880f15b785e588685c921913
-      type: https
-      path: "/"
-    pupmod-simp-ssh:
-      ref: 7feb682fd913475937f1b523c9d5f9fc9ca9e2d8
-      type: https
-      path: "/"
-    pupmod-simp-sssd:
-      ref: '054658fac130254c624c12f1c6c06fd45f2623d2'
-      type: https
-      path: "/"
-    puppetlabs-stdlib:
-      ref: 7904016024f78769c9ca805380c81ed5134d3bd4
-      type: https
-      path: "/"
-    pupmod-simp-stunnel:
-      ref: 2ccfe97eb0c0e0d71ea79767cb05addff3b177f7
-      type: https
-      path: "/"
-    pupmod-simp-sudo:
-      ref: 676802b5493647ae3ef7c24316e2debdcf2338e3
-      type: https
-      path: "/"
-    pupmod-simp-sudosh:
-      ref: 7395e24ed6b35f3d6cddf8312957dffcad918c0c
-      type: https
-      path: "/"
-    pupmod-simp-svckill:
-      ref: edefa2cddba1ba4db479e7f57e2f74cab1c2f1d4
-      type: https
-      path: "/"
-    pupmod-simp-sysctl:
-      ref: 5bc5680d27e04a864612827dc1cb78117bfa8ef9
-      type: https
-      path: "/"
-    pupmod-simp-tcpwrappers:
-      ref: e36d6a3713e4a7ecc5fa80334fbc02ee4646cc95
-      type: https
-      path: "/"
-    pupmod-simp-tftpboot:
-      ref: 5cc58ef199fe284e1478be2ddf0218927c33ba72
-      type: https
-      path: "/"
-    pupmod-simp-tpm:
-      ref: 2848701c2ec65de1afd7e8ac613c26cb969a669a
-      type: https
-      path: "/"
-    pupmod-simp-upstart:
-      ref: 62fa6bb7c7a335c991669f9574398035bd37f500
-      type: https
-      path: "/"
-    pupmod-simp-vnc:
-      ref: af565396270d1d59c412cb171bdcfe4e76857e37
-      type: https
-      path: "/"
-    pupmod-simp-vsftpd:
-      ref: ba05bc981c0cf0420dd3ce0f8aea5b95a0e25d38
-      type: https
-      path: "/"
-    pupmod-simp-windowmanager:
-      ref: a7965043d6700620c421d57a440d37d5b4cc47bc
-      type: https
-      path: "/"
-    pupmod-simp-xinetd:
-      ref: 88cc3bc015f3de2296fce0d546d1b41963deca61
-      type: https
-      path: "/"
-    pupmod-simp-xwindows:
-      ref: 8422b708e231b1c8fae0c2f635249c8c1ef9dbbc
-      type: https
-      path: "/"
-    pupmod-compliance:
-      ref: 8f45fd473d810c84de1b86a7d8f3b6ac80df205a
-      type: https
-      path: "/"
+    components:
+      simp-doc:
+        ref: fb3ec26f55a2ae5c24fa614de5fd4188af69b718
+        type: https
+        path: "/"
+      simp-rsync:
+        ref: 1a1f54ebd4c8cdf39e651ff715cb761cc364047e
+        type: https
+        path: "/"
+      rubygem-simp-cli:
+        ref: 97f01588c11ffd08a6660eb6d13dbcfb86688416
+        type: https
+        path: "/"
+      rubygem-simp-rake-helpers:
+        ref: 58ae09bd62e2c842e596f3f04c0486285818feb7
+        type: https
+        path: "/"
+      pupmod-simp-acpid:
+        ref: fede42bc5b2898418cde3a955f5c2457909be2a3
+        type: https
+        path: "/"
+      pupmod-simp-activemq:
+        ref: c8c1228313b1435e6de2a32dbfe813dac9cfcfac
+        type: https
+        path: "/"
+      pupmod-simp-aide:
+        ref: 6881ed821a39e5f455d49f7a19e0a03f23d2e674
+        type: https
+        path: "/"
+      pupmod-simp-apache:
+        ref: e581d98015ca6e2e47dacf3497d34f341ee6ab79
+        type: https
+        path: "/"
+      pupmod-simp-auditd:
+        ref: 6e53bf42173ac4b8a1e28b146347ba3cd11013e3
+        type: https
+        path: "/"
+      augeasproviders:
+        ref: 5813ab82ba9adc7272f1780b9bdb176ac50987aa
+        type: https
+        path: "/"
+      augeasproviders_apache:
+        ref: fd31e7332fc164e9ed14812531cc1bfd1fd0571e
+        type: https
+        path: "/"
+      augeasproviders_base:
+        ref: 5c38730f1099c823e45bf55434b37066ed981948
+        type: https
+        path: "/"
+      augeasproviders_core:
+        ref: 5ccde88a4e95de0b33bb7a9052aa0a7a63cde08f
+        type: https
+        path: "/"
+      augeasproviders_grub:
+        ref: fce9b2eabd3c1d3c9a09c4f1f5862ec11d4b06bb
+        type: https
+        path: "/"
+      augeasproviders_mounttab:
+        ref: e43627ba1dba50161117e5ab0ac203a05a90596c
+        type: https
+        path: "/"
+      augeasproviders_nagios:
+        ref: 2c7d49638ec39469a1003e7d325f7f38d6648d55
+        type: https
+        path: "/"
+      augeasproviders_pam:
+        ref: 3837cb601afaca5cae9be467a88d03289d1e61bd
+        type: https
+        path: "/"
+      augeasproviders_postgresql:
+        ref: 957bbdc5b5ca1a016c934c964420e32858b755a2
+        type: https
+        path: "/"
+      augeasproviders_puppet:
+        ref: 6e1582f3687fc99c773891a4a64935aa985c2004
+        type: https
+        path: "/"
+      augeasproviders_shellvar:
+        ref: d332a6de6b43ba3e5e64f1fa855eb4f5666042dc
+        type: https
+        path: "/"
+      augeasproviders_ssh:
+        ref: 79a33d5b8dcb0051006822ea8214c8b016ed0cf2
+        type: https
+        path: "/"
+      augeasproviders_sysctl:
+        ref: df7ce67de6bd3ee99c188e223c2e9c06d2b25877
+        type: https
+        path: "/"
+      pupmod-simp-autofs:
+        ref: 61224db6dac462966574869fc153c4530585c47b
+        type: https
+        path: "/"
+      pupmod-simp-clamav:
+        ref: dcda570b4eafa2a512a2f5310c61f449193d835a
+        type: https
+        path: "/"
+      pupmod-simp-concat:
+        ref: 148e368649ca1f86b562392015c16d3a68e8ea39
+        type: https
+        path: "/"
+      puppet-datacat:
+        ref: 2a4d19093cce94c4ab75033ac5422458c3fc1c0c
+        type: https
+        path: "/"
+      pupmod-simp-dhcp:
+        ref: 31f355a175b562ba1e167779b193bf57785c78ff
+        type: https
+        path: "/"
+      puppet-elasticsearch:
+        ref: e923d23b77f79355ca615d605a9f4e94ac78a315
+        type: https
+        path: "/"
+      pupmod-simp-foreman:
+        ref: abecc39bfa1cf4526026414b4da2552b95ab5c50
+        type: https
+        path: "/"
+      pupmod-simp-freeradius:
+        ref: c7d369fc663f71fe8ac1260e7ccc53476d19f1eb
+        type: https
+        path: "/"
+      pupmod-simp-ganglia:
+        ref: da32cef6cd0768cc906dbc932bafd3d75b470013
+        type: https
+        path: "/"
+      puppet-gpasswd:
+        ref: 68bc6fbb9d1b6e4cedbc84df2f40517819d14d28
+        type: https
+        path: "/"
+      puppetlabs-inifile:
+        ref: 821bad1cccfac9c9a46917d6b304d6a99878d60e
+        type: https
+        path: "/"
+      pupmod-simp-iptables:
+        ref: 893e645994108c18ed2d45fe295ce0d79e25def5
+        type: https
+        path: "/"
+      puppetlabs-java:
+        ref: d32802e712566abfcbe856479958f72c670891b9
+        type: https
+        path: "/"
+      puppetlabs-java_ks:
+        ref: 4ed1045f8aef04cbd86a74fa524c20c77e4a4caf
+        type: https
+        path: "/"
+      pupmod-simp-kibana:
+        ref: 275ee292b2e9eda627b422e13fbdddbf262e1bc9
+        type: https
+        path: "/"
+      pupmod-simp-libvirt:
+        ref: c30b56e6d9394e867dd32371750543cf071d96db
+        type: https
+        path: "/"
+      pupmod-simp-logrotate:
+        ref: 077437dcd6f4c845af064885fb25dde95c843993
+        type: https
+        path: "/"
+      puppet-logstash:
+        ref: 9e95519fb97f3382daa3e096a752515c3075b654
+        type: https
+        path: "/"
+      pupmod-simp-mcafee:
+        ref: eb65517bf77231e143b2cd467e4a248159ef72a6
+        type: https
+        path: "/"
+      pupmod-simp-mcollective:
+        ref: 3c8ca316af914a07898605aa74578a8ead9e0c98
+        type: https
+        path: "/"
+      pupmod-simp-mozilla:
+        ref: 0d69b8845fbbe736ee35ad0737ae4dc74b920729
+        type: https
+        path: "/"
+      puppetlabs-mysql:
+        ref: 0701aa404ce36905426157b65472b0be243d2d24
+        type: https
+        path: "/"
+      pupmod-simp-named:
+        ref: 80e3c049ac8fc1a625bef3ec87884e1b7faa2f6a
+        type: https
+        path: "/"
+      pupmod-simp-network:
+        ref: 0d64e947f90c9fb1ea07e693f4620d78eba2d992
+        type: https
+        path: "/"
+      pupmod-simp-nfs:
+        ref: 14ac95db1561252a8d0c2487a10a06f629008d77
+        type: https
+        path: "/"
+      pupmod-simp-nscd:
+        ref: 348541f1dad0456bec66ff5fdab229d7ba968bc5
+        type: https
+        path: "/"
+      pupmod-simp-ntpd:
+        ref: f18b5b4f1c04e45591201d894d15c51b16f5989d
+        type: https
+        path: "/"
+      pupmod-simp-oddjob:
+        ref: 3ff2ab29202d5654209f31c61549e3e35ca42af0
+        type: https
+        path: "/"
+      pupmod-simp-openldap:
+        ref: 3cab9eae35e759cb33da998bc589e128efc8bfb5
+        type: https
+        path: "/"
+      pupmod-simp-openscap:
+        ref: 060721aaf97d5a1a63ff23b594b75bb820c604fc
+        type: https
+        path: "/"
+      pupmod-simp-pam:
+        ref: a8ad6a094281d7be11465132a0c51f77d11865e0
+        type: https
+        path: "/"
+      pupmod-simp-pki:
+        ref: 1afafc2d063ae0b7f3e69f19649913665a5a7326
+        type: https
+        path: "/"
+      pupmod-simp-polkit:
+        ref: 307b8c6937efea6a2ae5fdaadd28f575d1664229
+        type: https
+        path: "/"
+      pupmod-simp-postfix:
+        ref: e4a440fd0cddd4f3f891e0aa1ff73aced6a20d87
+        type: https
+        path: "/"
+      puppetlabs-postgresql:
+        ref: 06b31e750349b884ef6221b37fdb77c5e8093142
+        type: https
+        path: "/"
+      pupmod-simp-pupmod:
+        ref: d1caebf1195055740a43a725a0966371cb8a1902
+        type: https
+        path: "/"
+      puppetlabs-puppetdb:
+        ref: 2fdaacaf0ef575a635f78f8b9bdfb606cb36213f
+        type: https
+        path: "/"
+      puppetlabs-apache:
+        ref: 8c2a381b9e70b8093c18e4225e393edc1f63f489
+        type: https
+        path: "/"
+      pupmod-simp-rsync:
+        ref: fa1b1af84f4a6041735fef202b002647504f3c2f
+        type: https
+        path: "/"
+      pupmod-simp-rsyslog:
+        ref: 3f95cceb05e091e81662bd128766ace01c6063c4
+        type: https
+        path: "/"
+      pupmod-simp-selinux:
+        ref: cb9c080b1c9ed9a69c4fffa195cf12314405fd09
+        type: https
+        path: "/"
+      pupmod-simp-simp:
+        ref: 75478d194e6837ab62c39629a5e1d74981e17cfe
+        type: https
+        path: "/"
+      pupmod-simp-simplib:
+        ref: 7409ed3f70a82eb903834f713783612c84a24622
+        type: https
+        path: "/"
+      pupmod-simp-site:
+        ref: 151404c332df081cbdb3c048b59dc47004492855
+        type: https
+        path: "/"
+      pupmod-simp-snmpd:
+        ref: 79e754567920cf1f880f15b785e588685c921913
+        type: https
+        path: "/"
+      pupmod-simp-ssh:
+        ref: 7feb682fd913475937f1b523c9d5f9fc9ca9e2d8
+        type: https
+        path: "/"
+      pupmod-simp-sssd:
+        ref: '054658fac130254c624c12f1c6c06fd45f2623d2'
+        type: https
+        path: "/"
+      puppetlabs-stdlib:
+        ref: 7904016024f78769c9ca805380c81ed5134d3bd4
+        type: https
+        path: "/"
+      pupmod-simp-stunnel:
+        ref: 2ccfe97eb0c0e0d71ea79767cb05addff3b177f7
+        type: https
+        path: "/"
+      pupmod-simp-sudo:
+        ref: 676802b5493647ae3ef7c24316e2debdcf2338e3
+        type: https
+        path: "/"
+      pupmod-simp-sudosh:
+        ref: 7395e24ed6b35f3d6cddf8312957dffcad918c0c
+        type: https
+        path: "/"
+      pupmod-simp-svckill:
+        ref: edefa2cddba1ba4db479e7f57e2f74cab1c2f1d4
+        type: https
+        path: "/"
+      pupmod-simp-sysctl:
+        ref: 5bc5680d27e04a864612827dc1cb78117bfa8ef9
+        type: https
+        path: "/"
+      pupmod-simp-tcpwrappers:
+        ref: e36d6a3713e4a7ecc5fa80334fbc02ee4646cc95
+        type: https
+        path: "/"
+      pupmod-simp-tftpboot:
+        ref: 5cc58ef199fe284e1478be2ddf0218927c33ba72
+        type: https
+        path: "/"
+      pupmod-simp-tpm:
+        ref: 2848701c2ec65de1afd7e8ac613c26cb969a669a
+        type: https
+        path: "/"
+      pupmod-simp-upstart:
+        ref: 62fa6bb7c7a335c991669f9574398035bd37f500
+        type: https
+        path: "/"
+      pupmod-simp-vnc:
+        ref: af565396270d1d59c412cb171bdcfe4e76857e37
+        type: https
+        path: "/"
+      pupmod-simp-vsftpd:
+        ref: ba05bc981c0cf0420dd3ce0f8aea5b95a0e25d38
+        type: https
+        path: "/"
+      pupmod-simp-windowmanager:
+        ref: a7965043d6700620c421d57a440d37d5b4cc47bc
+        type: https
+        path: "/"
+      pupmod-simp-xinetd:
+        ref: 88cc3bc015f3de2296fce0d546d1b41963deca61
+        type: https
+        path: "/"
+      pupmod-simp-xwindows:
+        ref: 8422b708e231b1c8fae0c2f635249c8c1ef9dbbc
+        type: https
+        path: "/"
+      pupmod-compliance:
+        ref: 8f45fd473d810c84de1b86a7d8f3b6ac80df205a
+        type: https
+        path: "/"
+    platforms:
+      CentOS-7.2-x86_64:
+      RedHat-7.2-x86_64:

--- a/v1/releases/5.2.0-0.yaml
+++ b/v1/releases/5.2.0-0.yaml
@@ -1,367 +1,371 @@
 ---
 releases:
   5.2.0-0:
-    simp-doc:
-      ref: 2487fe946410fb4b428796d2376f7c1b8e344e60
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: 8dcf5878387311664c49349f18b161eb67229dae
-      type: https
-      path: "/src/puppet/modules"
-    rubygem-simp-cli:
-      ref: abc20ee23740cbb235875d18c4221c940d51b9c7
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: b63c0bd130897256f645d80af2bb958d2fd5448e
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: d02c78b014be9310eabbbb7d8267475efcf70e07
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: 9263e36c1803f9f83b6eb5e5ca3ff9b4f8cd0522
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: 89684597706048ae9df4bd2567d6be13682f9795
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: 934f915f85080b809900453868e8440444c9d4c3
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: 5e30c901f8358156873d7098c609f60697fb5ee5
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: bebe87262e32c7a2606f0d4b4e1200921730a105
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: 48c30bcaf453da36281104b5387d4a6ba44bbf93
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: 5cbcbbc2f185954edea1a63b29c6684d687e484e
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: 82dbe6518159e080f865425da3daa250305dd26a
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: e666487674fc98ae0c530686f819174179ffe046
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: 4b5b5f7e6c2c86ef7f924ac92b92e0d32f669e63
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: a9b2991447d1305d8d4fc1e98b4c1d1e06750566
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: 91a256e8aab5a76df07144fcff1e54ac9af7a815
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: ea5e3357ef5f2abf3eaa998fd39c6c61ded807ba
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: f235c7b032a6abca5b73687221a8fdf8f151691a
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: 48b6bbc2e86c79670f5057813d70c3ba60789fd0
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: 44154f381f7d3e692dae93b5bf05d4c1d9563217
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: 625ce220bae00f1c37415d9fdacc44c7c02d65b3
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: b4478aba815d5e7e9a9f82ca0f59533e312bf954
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: ebaf91499f75db3df60bd432561a9adc093bc999
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: 565bb7339e9fc0831d14545a9d2262d922878848
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 5a02c573242171c8d8210607fb19c766b2c4632f
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: 2da631be16147f153b7d0d3c52014d474e93e619
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: 810eb3f6b8d69726a7bd2db78088703dfa81d547
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: e0bd50b92d9b85effacce3a40e4b0ca1b8c1fc3b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: be08dac7e0d7cfed0441ca523383563592243c12
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: d9acbefb998777bc47a59c1f2484c1529bc553a7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: 7f6fbc1faf8e9bc8830d6a529af444dc9b2d2302
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: 955b492aa7563e72ab896b4e4800f633a759608f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: 5446e05d9905e80a4511fb06c6175786593bb157
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-concat:
-      ref: 72421a7c67788cbd17b1efa0508741c6b0c2a8b8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: 7e0f9dc0b5e1114ab39efca1ee082f138226c7cb
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-foreman:
-      ref: a42210f237d7e68af1a740a46d38119cd13ff6e8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: d6e0e3bc28742f58f15b3276d972529dd5db76e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ganglia:
-      ref: 70323b955b4233cdab40a34a6c6ac89397271dc5
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: 8610ae8b38b25e2c2bf502d6a82064915a4240e4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: 2424e13d7cd62b6679f4d3d8617ecacec841e8ae
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: a2cd576f707416128fb6c4e15dbd2a485941b43b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 783a7562d755e5e29fc2e5d4c8afd7fdd7e44b77
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libreswan:
-      ref: 9d46443842ff22885c3dccc57ea1708d0e3e5c06
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: '02826504bb2babe2b37063cc937cad3c59013bde'
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: 7bf9e44d055fc4ac9f81a601098b6209ffad3d80
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: 31386d5c602064e411769ef10288a729e20a185b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: c5f52de139d66361852f86ac3e13f7b490cbf14b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: 8ef627aad451d2d51a2b249ae21dbc2ba349098f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: 115bfae2a34cb97cd4f93f032068932587372e29
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 950edad163869ec894710f26f208b74e67828e8e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 243361d38726fdfea26ee3a349009b6d75aa2e21
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nscd:
-      ref: b3010a717cf8d4706b0c24782acf36fd8b2726af
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: 34f76d9e0e585b20de83b2f46f7c1337d8b5e748
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 8c7cc73766936278e3f97ecb90525ce0307e20ee
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openldap:
-      ref: 9847a8f30a6bffef6db2afa92dc71bf6d1abd409
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: 4a44514a30f47fa5ac36e77bc480b053731278cf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: 152871b905e78ee15951109a8d358241c28c0dc8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: 68fc208331e8f52da068eb77df882972bc801d46
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 4bd15a6c82cbb3f92daa77c2ab78c558c5768e26
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: 5a5480fb20fa5603958c3b65e8dffc02a6ea9f02
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: f2262a546365a96051ab27434ae69c7386ac6c0e
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 92dd2a464fa64eb802735f32b4cca6771fee48d7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: 4b7849e1de7d92deb6c9575b0ccd44b584d02829
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: 662b3220db3e885c87c75b41854083a447f78055
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: 4b9e53ae884a39296b21482ccf3db066f8df6278
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: ee7a6797f11b9dff18f7d0150e571ab95461a58d
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: a384a87dcc79bfc2cf9fbf754756fb38198cc44f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: 170b8590309ee358577a6ff24fb23829a06c680e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: aba8d486d8fa23a6903d6c327e55f6b48b68cb12
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 276e372aee1dc5b9cc70d6f1d0e697aeb05b9b16
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-snmpd:
-      ref: 4e6378976c24a387c66bf948f3c32b634c11d2ac
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: 533f5f383d5adeed143de938aa21b271c07a87cd
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: 22d0a4f96eb6369cee62808197c327f16dbd7cbf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 25884a2df15a7e307d4ebc307709a5eecc7d1e38
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: 4087d1f101f1bc4f6c315711466406321af969be
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: a8cab11c5aff8eaf0e2468518d72fb107a6c26a0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: b64aa7bc38402a44922c56508c0d9cbd42d11f94
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sysctl:
-      ref: fd7fee7000de3cb8436aad81d3ec91610b804c88
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: 18cd645cec646b67b7dfd3e21d3a677861680a64
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: 296b23bc4697a1aa5a53d72bccceef5d794a0b79
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 9f0d2e6f2c12c3cdcaf50dd19d8a7bea28c7899b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: f021e87802603c0474e5b990e345d9c8c67d42e0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 631acad574a928eacc83a6fc85dd249f8a12eab3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: 07ecc2acc92d99429607771854701680c61e3cdc
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-windowmanager:
-      ref: 2c3ab26ed74ff5174addf402c3549e40134fec46
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: c92b0b6e86c59b7d30cca114326b6984b53d1ed8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xwindows:
-      ref: f4eebdb1f1d8874a5db59b9193dcd5dfda27c7e2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: cfed507b768bdcced60d3091e0d54d673b27763d
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 2487fe946410fb4b428796d2376f7c1b8e344e60
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: 8dcf5878387311664c49349f18b161eb67229dae
+        type: https
+        path: "/src/puppet/modules"
+      rubygem-simp-cli:
+        ref: abc20ee23740cbb235875d18c4221c940d51b9c7
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: b63c0bd130897256f645d80af2bb958d2fd5448e
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: d02c78b014be9310eabbbb7d8267475efcf70e07
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: 61a6a6ede60193d9ad3eafe12278cd44a46d7ebc
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: 9263e36c1803f9f83b6eb5e5ca3ff9b4f8cd0522
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: 89684597706048ae9df4bd2567d6be13682f9795
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: 934f915f85080b809900453868e8440444c9d4c3
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: 5e30c901f8358156873d7098c609f60697fb5ee5
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: bebe87262e32c7a2606f0d4b4e1200921730a105
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: 48c30bcaf453da36281104b5387d4a6ba44bbf93
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: 5cbcbbc2f185954edea1a63b29c6684d687e484e
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: 82dbe6518159e080f865425da3daa250305dd26a
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: e666487674fc98ae0c530686f819174179ffe046
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: 4b5b5f7e6c2c86ef7f924ac92b92e0d32f669e63
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: a9b2991447d1305d8d4fc1e98b4c1d1e06750566
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: 91a256e8aab5a76df07144fcff1e54ac9af7a815
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: ea5e3357ef5f2abf3eaa998fd39c6c61ded807ba
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: f235c7b032a6abca5b73687221a8fdf8f151691a
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: 48b6bbc2e86c79670f5057813d70c3ba60789fd0
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: 44154f381f7d3e692dae93b5bf05d4c1d9563217
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: 625ce220bae00f1c37415d9fdacc44c7c02d65b3
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: b4478aba815d5e7e9a9f82ca0f59533e312bf954
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: ebaf91499f75db3df60bd432561a9adc093bc999
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: 565bb7339e9fc0831d14545a9d2262d922878848
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 5a02c573242171c8d8210607fb19c766b2c4632f
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: 2da631be16147f153b7d0d3c52014d474e93e619
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: 810eb3f6b8d69726a7bd2db78088703dfa81d547
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: e0bd50b92d9b85effacce3a40e4b0ca1b8c1fc3b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: be08dac7e0d7cfed0441ca523383563592243c12
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: d9acbefb998777bc47a59c1f2484c1529bc553a7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: 7f6fbc1faf8e9bc8830d6a529af444dc9b2d2302
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: 955b492aa7563e72ab896b4e4800f633a759608f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: 5446e05d9905e80a4511fb06c6175786593bb157
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-concat:
+        ref: 72421a7c67788cbd17b1efa0508741c6b0c2a8b8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: 7e0f9dc0b5e1114ab39efca1ee082f138226c7cb
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-foreman:
+        ref: a42210f237d7e68af1a740a46d38119cd13ff6e8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: d6e0e3bc28742f58f15b3276d972529dd5db76e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ganglia:
+        ref: 70323b955b4233cdab40a34a6c6ac89397271dc5
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: 8610ae8b38b25e2c2bf502d6a82064915a4240e4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: 2424e13d7cd62b6679f4d3d8617ecacec841e8ae
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: a2cd576f707416128fb6c4e15dbd2a485941b43b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 783a7562d755e5e29fc2e5d4c8afd7fdd7e44b77
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libreswan:
+        ref: 9d46443842ff22885c3dccc57ea1708d0e3e5c06
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: '02826504bb2babe2b37063cc937cad3c59013bde'
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: 7bf9e44d055fc4ac9f81a601098b6209ffad3d80
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: 31386d5c602064e411769ef10288a729e20a185b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: c5f52de139d66361852f86ac3e13f7b490cbf14b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: 8ef627aad451d2d51a2b249ae21dbc2ba349098f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: 115bfae2a34cb97cd4f93f032068932587372e29
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 950edad163869ec894710f26f208b74e67828e8e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 243361d38726fdfea26ee3a349009b6d75aa2e21
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nscd:
+        ref: b3010a717cf8d4706b0c24782acf36fd8b2726af
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: 34f76d9e0e585b20de83b2f46f7c1337d8b5e748
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 8c7cc73766936278e3f97ecb90525ce0307e20ee
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openldap:
+        ref: 9847a8f30a6bffef6db2afa92dc71bf6d1abd409
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: 4a44514a30f47fa5ac36e77bc480b053731278cf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: 152871b905e78ee15951109a8d358241c28c0dc8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: 68fc208331e8f52da068eb77df882972bc801d46
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 4bd15a6c82cbb3f92daa77c2ab78c558c5768e26
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: 5a5480fb20fa5603958c3b65e8dffc02a6ea9f02
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: f2262a546365a96051ab27434ae69c7386ac6c0e
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 92dd2a464fa64eb802735f32b4cca6771fee48d7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: 4b7849e1de7d92deb6c9575b0ccd44b584d02829
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: 662b3220db3e885c87c75b41854083a447f78055
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: 4b9e53ae884a39296b21482ccf3db066f8df6278
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: ee7a6797f11b9dff18f7d0150e571ab95461a58d
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: a384a87dcc79bfc2cf9fbf754756fb38198cc44f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: 170b8590309ee358577a6ff24fb23829a06c680e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: aba8d486d8fa23a6903d6c327e55f6b48b68cb12
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 276e372aee1dc5b9cc70d6f1d0e697aeb05b9b16
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-snmpd:
+        ref: 4e6378976c24a387c66bf948f3c32b634c11d2ac
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: 533f5f383d5adeed143de938aa21b271c07a87cd
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: 22d0a4f96eb6369cee62808197c327f16dbd7cbf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 25884a2df15a7e307d4ebc307709a5eecc7d1e38
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: 4087d1f101f1bc4f6c315711466406321af969be
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: a8cab11c5aff8eaf0e2468518d72fb107a6c26a0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: b64aa7bc38402a44922c56508c0d9cbd42d11f94
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sysctl:
+        ref: fd7fee7000de3cb8436aad81d3ec91610b804c88
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: 18cd645cec646b67b7dfd3e21d3a677861680a64
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: 296b23bc4697a1aa5a53d72bccceef5d794a0b79
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 9f0d2e6f2c12c3cdcaf50dd19d8a7bea28c7899b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: f021e87802603c0474e5b990e345d9c8c67d42e0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 631acad574a928eacc83a6fc85dd249f8a12eab3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: 07ecc2acc92d99429607771854701680c61e3cdc
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-windowmanager:
+        ref: 2c3ab26ed74ff5174addf402c3549e40134fec46
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: c92b0b6e86c59b7d30cca114326b6984b53d1ed8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xwindows:
+        ref: f4eebdb1f1d8874a5db59b9193dcd5dfda27c7e2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: cfed507b768bdcced60d3091e0d54d673b27763d
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-7.2-x86_64:
+      RedHat-7.2-x86_64:

--- a/v1/releases/5.2.1-0.yaml
+++ b/v1/releases/5.2.1-0.yaml
@@ -1,375 +1,379 @@
 ---
 releases:
   5.2.1-0:
-    simp-doc:
-      ref: 37dd99c99af38e7fb40a34d0b1b699fcadaee726
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: 72de5f3d840b56035c729b41cdbb218136f0673c
-      type: https
-      path: "/src/puppet/modules"
-    rubygem-simp-cli:
-      ref: 865e88acb9a457362065dff80e3d73d6e4024386
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
-      type: https
-      path: "/src/puppet/modules"
-    puppet-elasticsearch:
-      ref: a78bb99b3433205ada75febcf4a91b510caa9ce4
-      type: https
-      path: "/src/puppet/modules"
-    puppet-logstash:
-      ref: 61a9d3d83c184bda7e935154fcc295e40bda924a
-      type: https
-      path: "/src/puppet/modules"
-    puppet-file_concat:
-      ref: decefc4e2a36580a52818f72f0a054e0088a1b6e
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders:
-      ref: 69b80fee1e1ae13a0e120c46155cad1cfbde70b9
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_apache:
-      ref: 57e1671c51e44400d29d977d2381d30690c5d923
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_base:
-      ref: 9e8c99bc2298e4da3961474d3f4e07f2037ae8dd
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_core:
-      ref: ee2147a12008f4ef20a40f0f366064b86b5a7f65
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_grub:
-      ref: 16858eb5b4370e3242b4b153af597fa5cbe3b75d
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_mounttab:
-      ref: 4abc6ea682e9bb8e4a5d8b781ded33e601e11003
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_nagios:
-      ref: 3e54f665cb6b2e18c603bb3697d21c6bd6141e59
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_pam:
-      ref: 7e58204da822597614e3440505e61a8e24af532a
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_postgresql:
-      ref: 259c80fb874c749ec4bf6ecbb81b53ff7765689c
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_puppet:
-      ref: 544577195bbe4b3b9e14c3b97daec2cb527b2ada
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_shellvar:
-      ref: 983ad018810381d6cc7b523dd09813d1d5c36227
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_ssh:
-      ref: 203f848a6373a3ca5d9f1744d7f616fbb1212bc3
-      type: https
-      path: "/src/puppet/modules"
-    augeasproviders_sysctl:
-      ref: f8d932d07acb8a3004ba83ed7a34fbafa2a19a0e
-      type: https
-      path: "/src/puppet/modules"
-    puppet-gpasswd:
-      ref: 71294cf36bd80d26cfdfd7608c18e543c0d96298
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-inifile:
-      ref: 32b9809a198a732b1d80d5a53c9187b9f77a84b3
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java:
-      ref: 6efaf0babec70adb2c3422660c313870ec17f04b
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-java_ks:
-      ref: 54728003a07b74f39964eb6c56e92cf071b6d8f1
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-mysql:
-      ref: '078c99bdb1e26a4081b58298abf153ba25d52800'
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-postgresql:
-      ref: 0ecc08653d9bf51fe9096a6321926f9c8cc38ab1
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-apache:
-      ref: 70ac888d8df727267e9e159b3c18e2e1b2a0e202
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-stdlib:
-      ref: 300ea24e7b9102c6d14424bed1fe3c4d5fc08057
-      type: https
-      path: "/src/puppet/modules"
-    puppet-datacat:
-      ref: e33d7b96ffe4121e0fd0297f51e6a8981549b6ed
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-acpid:
-      ref: 86c1e5bc2cf95babd04a37777997a00156f8dc0f
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-activemq:
-      ref: e6c3b06b661ae26dd3215fdc8d82904115c25e2c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-aide:
-      ref: bb6307f7b4fb0e283fb89146ee0e50385666c733
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-apache:
-      ref: 6b85606df3bd1d3943c3d2c85e6d01e5deaa9ce3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-auditd:
-      ref: 21a7b59b110f61b731eb3fe6c773ffe569d0054a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-autofs:
-      ref: f8246519048d62928f68cc97bce5c5fa86d4b5aa
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-clamav:
-      ref: a7dde5af88f40d25ea3de94605ae8885c0e11303
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-concat:
-      ref: 747f4e02713b32c3032d57b24f57a4c690a37e3c
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dhcp:
-      ref: e080364fc93be0d18538844d6aca6110aea7427e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-dirtycow:
-      ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-foreman:
-      ref: c1ee8d60797430fbf2cc6c296523c6e34fd3a522
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-freeradius:
-      ref: a4093c8c8984f9072bbcf51c2c4fc0ac5e52048e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ganglia:
-      ref: b5e2606246bbae322a2a2efcee7d699833cd089f
-      type: https
-      path: "/src/puppet/modules"
-    puppet-haveged:
-      ref: 8e102613db7181fde39b54481bc17a1640abf504
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-iptables:
-      ref: d6594ff6bb3de07a222684ead202049bebe44a3e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-jenkins:
-      ref: 400d8dddb3b41262a682f9ebfd7fb694593ce2b0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-journald:
-      ref: 26e4c303fd7bd6c61db469cbc63616e82a6f425b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-krb5:
-      ref: 79d504724035b9d90891083943d8bc768a59e335
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libreswan:
-      ref: 6ed2c808b91205866b8689d876dbffb02c634eb2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-libvirt:
-      ref: df2ae56a7ddb26fb3298129057c1ab5b9a734467
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-logrotate:
-      ref: c9beaa857ccc1ba574fe9776cfb633d0afeb47a1
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcafee:
-      ref: 4cfd91158d36c64ce3bcc41d6149ea7cf7cddb54
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mcollective:
-      ref: eae813299ba133c7dd87daf34cf650747f5303a0
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-mozilla:
-      ref: 22e6f560de43536b366423c4df6da8e671cfb418
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-named:
-      ref: 311374cc39d79645cf6b087575b30fea6751c089
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-network:
-      ref: 07adaa8e15ce55c7fa29b76152cd0d10ecbd6103
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nfs:
-      ref: 6055a1ee3222f2a74d854c587f678d55d0a2c7b7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-nscd:
-      ref: c574fe6a45a7589a78da4d12291753614c955fa5
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ntpd:
-      ref: 3ca80d08c1ad800a20ca8fb5aa29a756d51db3ec
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-oddjob:
-      ref: 1f2ccc4ba474fe68dc815f4df9bdf5547c7a2355
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openldap:
-      ref: 89036f7e182de073cbba13834a58fa569b6589c4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-openscap:
-      ref: 794f4a6c733faa5bbb646fe9349cb5199cdacc7e
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pam:
-      ref: ae14c45acb3b849b5a44bd9eb7c7729afaf0330a
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pki:
-      ref: eeda24b447b2ef3ede8347f6f891e82bc40482e7
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-polkit:
-      ref: 0f2099180fc7688afaafe7b67ce4e65da1c714ae
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-postfix:
-      ref: c8eaec5efdd53c421718e6b76b82bb9d5a4596c8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-pupmod:
-      ref: fc907515d15beadd08bb2d979db83942fa51d11a
-      type: https
-      path: "/src/puppet/modules"
-    puppetlabs-puppetdb:
-      ref: 353e735893b6bcf1d6833e2a82dfcd6c511535d8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-rsyslog:
-      ref: 6cac3218633a01e14d18e365b31fb0aa11363ce4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-selinux:
-      ref: d4c4e8b07a2a65f0b1f927231d7b7a2c084474b3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp:
-      ref: e3c8a7b649ae717a63035dddbda77abf5d3d5f90
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_elasticsearch:
-      ref: d3f7900abe840b34049af476fa9997d9cc4e39e2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_grafana:
-      ref: be45b100650ffcabcf9213bab095f54474a157c9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simp_logstash:
-      ref: 977e6e144db50ec60d5dd98a10d190f6189a4582
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-simplib:
-      ref: b638d890f1c3b685a75668b046efe0c0e8190596
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-site:
-      ref: 42ac183186ac30031685ab49fa94d0abf98d5dad
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-snmpd:
-      ref: fe37cf8cdea4b9e7e5c321b4cccdcbc98cd141d2
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-ssh:
-      ref: 0342da0d9cf9fe9df5c1c9445204635148867db8
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sssd:
-      ref: 4d912229a22cd8a2d1b751c53f12b03aace162fe
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-stunnel:
-      ref: 56246194b25e6369b9ecf59f1738c0837b238e36
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudo:
-      ref: 2f086f13dd9231dd9666351b3683b17e595dec52
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sudosh:
-      ref: 0c3599ca9709b770178f32b0b57b252018fc65fe
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-svckill:
-      ref: 31b86e74cdfee1fceb46356b0e0c8cfbfbf43326
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-sysctl:
-      ref: 6be0196003fdb201d04460b3e20156a978f80fa4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tcpwrappers:
-      ref: 7ca8448bb0c8d36e923e2fdceb84a7a4f0aff2c9
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tftpboot:
-      ref: 479dccf64719153ec9e6ea9924860686dc5921c4
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-tpm:
-      ref: 36a43b474f9a5f8d7b2f72469d1d19bf9e7f5baf
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-upstart:
-      ref: ce7d96ef122f7d0081509b2b8b81ab1dda541760
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vnc:
-      ref: 0d5cbbd41c40b7b783a12fc6be9c50da1594e20b
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-vsftpd:
-      ref: 2ec702899c9e55f07b52dffd7b00304e34894608
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-windowmanager:
-      ref: ab889b380396330b6e2608b8aefbda10f3b88816
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xinetd:
-      ref: 4b65dd0dec18f12f9f4b902a229cd7b135d1db79
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-xwindows:
-      ref: 0c5377cdcbad046653a532d867f230f3042260a3
-      type: https
-      path: "/src/puppet/modules"
-    pupmod-simp-compliance_markup:
-      ref: 3b746f000fe3c756b1d871c4d6b25583c705bfdb
-      type: https
-      path: "/src/puppet/modules"
+    components:
+      simp-doc:
+        ref: 37dd99c99af38e7fb40a34d0b1b699fcadaee726
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: 72de5f3d840b56035c729b41cdbb218136f0673c
+        type: https
+        path: "/src/puppet/modules"
+      rubygem-simp-cli:
+        ref: 865e88acb9a457362065dff80e3d73d6e4024386
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: bb106f5c511ea4f6c152d91c3a9be1344b168a7a
+        type: https
+        path: "/src/puppet/modules"
+      puppet-elasticsearch:
+        ref: a78bb99b3433205ada75febcf4a91b510caa9ce4
+        type: https
+        path: "/src/puppet/modules"
+      puppet-logstash:
+        ref: 61a9d3d83c184bda7e935154fcc295e40bda924a
+        type: https
+        path: "/src/puppet/modules"
+      puppet-file_concat:
+        ref: decefc4e2a36580a52818f72f0a054e0088a1b6e
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders:
+        ref: 69b80fee1e1ae13a0e120c46155cad1cfbde70b9
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_apache:
+        ref: 57e1671c51e44400d29d977d2381d30690c5d923
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_base:
+        ref: 9e8c99bc2298e4da3961474d3f4e07f2037ae8dd
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_core:
+        ref: ee2147a12008f4ef20a40f0f366064b86b5a7f65
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_grub:
+        ref: 16858eb5b4370e3242b4b153af597fa5cbe3b75d
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_mounttab:
+        ref: 4abc6ea682e9bb8e4a5d8b781ded33e601e11003
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_nagios:
+        ref: 3e54f665cb6b2e18c603bb3697d21c6bd6141e59
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_pam:
+        ref: 7e58204da822597614e3440505e61a8e24af532a
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_postgresql:
+        ref: 259c80fb874c749ec4bf6ecbb81b53ff7765689c
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_puppet:
+        ref: 544577195bbe4b3b9e14c3b97daec2cb527b2ada
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_shellvar:
+        ref: 983ad018810381d6cc7b523dd09813d1d5c36227
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_ssh:
+        ref: 203f848a6373a3ca5d9f1744d7f616fbb1212bc3
+        type: https
+        path: "/src/puppet/modules"
+      augeasproviders_sysctl:
+        ref: f8d932d07acb8a3004ba83ed7a34fbafa2a19a0e
+        type: https
+        path: "/src/puppet/modules"
+      puppet-gpasswd:
+        ref: 71294cf36bd80d26cfdfd7608c18e543c0d96298
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-inifile:
+        ref: 32b9809a198a732b1d80d5a53c9187b9f77a84b3
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java:
+        ref: 6efaf0babec70adb2c3422660c313870ec17f04b
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-java_ks:
+        ref: 54728003a07b74f39964eb6c56e92cf071b6d8f1
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-mysql:
+        ref: '078c99bdb1e26a4081b58298abf153ba25d52800'
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-postgresql:
+        ref: 0ecc08653d9bf51fe9096a6321926f9c8cc38ab1
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-apache:
+        ref: 70ac888d8df727267e9e159b3c18e2e1b2a0e202
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-stdlib:
+        ref: 300ea24e7b9102c6d14424bed1fe3c4d5fc08057
+        type: https
+        path: "/src/puppet/modules"
+      puppet-datacat:
+        ref: e33d7b96ffe4121e0fd0297f51e6a8981549b6ed
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-acpid:
+        ref: 86c1e5bc2cf95babd04a37777997a00156f8dc0f
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-activemq:
+        ref: e6c3b06b661ae26dd3215fdc8d82904115c25e2c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-aide:
+        ref: bb6307f7b4fb0e283fb89146ee0e50385666c733
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-apache:
+        ref: 6b85606df3bd1d3943c3d2c85e6d01e5deaa9ce3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-auditd:
+        ref: 21a7b59b110f61b731eb3fe6c773ffe569d0054a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-autofs:
+        ref: f8246519048d62928f68cc97bce5c5fa86d4b5aa
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-clamav:
+        ref: a7dde5af88f40d25ea3de94605ae8885c0e11303
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-concat:
+        ref: 747f4e02713b32c3032d57b24f57a4c690a37e3c
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dhcp:
+        ref: e080364fc93be0d18538844d6aca6110aea7427e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-dirtycow:
+        ref: af1fbbb1d4cfccd5fe99961ed77f16ff76db01d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-foreman:
+        ref: c1ee8d60797430fbf2cc6c296523c6e34fd3a522
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-freeradius:
+        ref: a4093c8c8984f9072bbcf51c2c4fc0ac5e52048e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ganglia:
+        ref: b5e2606246bbae322a2a2efcee7d699833cd089f
+        type: https
+        path: "/src/puppet/modules"
+      puppet-haveged:
+        ref: 8e102613db7181fde39b54481bc17a1640abf504
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-iptables:
+        ref: d6594ff6bb3de07a222684ead202049bebe44a3e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-jenkins:
+        ref: 400d8dddb3b41262a682f9ebfd7fb694593ce2b0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-journald:
+        ref: 26e4c303fd7bd6c61db469cbc63616e82a6f425b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-krb5:
+        ref: 79d504724035b9d90891083943d8bc768a59e335
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libreswan:
+        ref: 6ed2c808b91205866b8689d876dbffb02c634eb2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-libvirt:
+        ref: df2ae56a7ddb26fb3298129057c1ab5b9a734467
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-logrotate:
+        ref: c9beaa857ccc1ba574fe9776cfb633d0afeb47a1
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcafee:
+        ref: 4cfd91158d36c64ce3bcc41d6149ea7cf7cddb54
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mcollective:
+        ref: eae813299ba133c7dd87daf34cf650747f5303a0
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-mozilla:
+        ref: 22e6f560de43536b366423c4df6da8e671cfb418
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-named:
+        ref: 311374cc39d79645cf6b087575b30fea6751c089
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-network:
+        ref: 07adaa8e15ce55c7fa29b76152cd0d10ecbd6103
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nfs:
+        ref: 6055a1ee3222f2a74d854c587f678d55d0a2c7b7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-nscd:
+        ref: c574fe6a45a7589a78da4d12291753614c955fa5
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ntpd:
+        ref: 3ca80d08c1ad800a20ca8fb5aa29a756d51db3ec
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-oddjob:
+        ref: 1f2ccc4ba474fe68dc815f4df9bdf5547c7a2355
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openldap:
+        ref: 89036f7e182de073cbba13834a58fa569b6589c4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-openscap:
+        ref: 794f4a6c733faa5bbb646fe9349cb5199cdacc7e
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pam:
+        ref: ae14c45acb3b849b5a44bd9eb7c7729afaf0330a
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pki:
+        ref: eeda24b447b2ef3ede8347f6f891e82bc40482e7
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-polkit:
+        ref: 0f2099180fc7688afaafe7b67ce4e65da1c714ae
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-postfix:
+        ref: c8eaec5efdd53c421718e6b76b82bb9d5a4596c8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-pupmod:
+        ref: fc907515d15beadd08bb2d979db83942fa51d11a
+        type: https
+        path: "/src/puppet/modules"
+      puppetlabs-puppetdb:
+        ref: 353e735893b6bcf1d6833e2a82dfcd6c511535d8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-rsyslog:
+        ref: 6cac3218633a01e14d18e365b31fb0aa11363ce4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-selinux:
+        ref: d4c4e8b07a2a65f0b1f927231d7b7a2c084474b3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp:
+        ref: e3c8a7b649ae717a63035dddbda77abf5d3d5f90
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_elasticsearch:
+        ref: d3f7900abe840b34049af476fa9997d9cc4e39e2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_grafana:
+        ref: be45b100650ffcabcf9213bab095f54474a157c9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simp_logstash:
+        ref: 977e6e144db50ec60d5dd98a10d190f6189a4582
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-simplib:
+        ref: b638d890f1c3b685a75668b046efe0c0e8190596
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-site:
+        ref: 42ac183186ac30031685ab49fa94d0abf98d5dad
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-snmpd:
+        ref: fe37cf8cdea4b9e7e5c321b4cccdcbc98cd141d2
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-ssh:
+        ref: 0342da0d9cf9fe9df5c1c9445204635148867db8
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sssd:
+        ref: 4d912229a22cd8a2d1b751c53f12b03aace162fe
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-stunnel:
+        ref: 56246194b25e6369b9ecf59f1738c0837b238e36
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudo:
+        ref: 2f086f13dd9231dd9666351b3683b17e595dec52
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sudosh:
+        ref: 0c3599ca9709b770178f32b0b57b252018fc65fe
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-svckill:
+        ref: 31b86e74cdfee1fceb46356b0e0c8cfbfbf43326
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-sysctl:
+        ref: 6be0196003fdb201d04460b3e20156a978f80fa4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tcpwrappers:
+        ref: 7ca8448bb0c8d36e923e2fdceb84a7a4f0aff2c9
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tftpboot:
+        ref: 479dccf64719153ec9e6ea9924860686dc5921c4
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-tpm:
+        ref: 36a43b474f9a5f8d7b2f72469d1d19bf9e7f5baf
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-upstart:
+        ref: ce7d96ef122f7d0081509b2b8b81ab1dda541760
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vnc:
+        ref: 0d5cbbd41c40b7b783a12fc6be9c50da1594e20b
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-vsftpd:
+        ref: 2ec702899c9e55f07b52dffd7b00304e34894608
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-windowmanager:
+        ref: ab889b380396330b6e2608b8aefbda10f3b88816
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xinetd:
+        ref: 4b65dd0dec18f12f9f4b902a229cd7b135d1db79
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-xwindows:
+        ref: 0c5377cdcbad046653a532d867f230f3042260a3
+        type: https
+        path: "/src/puppet/modules"
+      pupmod-simp-compliance_markup:
+        ref: 3b746f000fe3c756b1d871c4d6b25583c705bfdb
+        type: https
+        path: "/src/puppet/modules"
+    platforms:
+      CentOS-7.2-x86_64:
+      RedHat-7.2-x86_64:

--- a/v1/releases/6.0.0-0.yaml
+++ b/v1/releases/6.0.0-0.yaml
@@ -1,531 +1,536 @@
 ---
 releases:
   6.0.0-0:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-      type: https
-      path: "/src"
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.2
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-      type: https
-      path: "/src/rubygems"
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-      type: https
-      path: "/src/puppet/modules"
-      tag: v2.5.0-34-g6d426d5
-    puppet-kmod:
-      ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.1.0
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp-0.11.0
-    puppet-logstash:
-      ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
-      type: https
-      path: "/src/puppet/modules"
-      tag: 5.0.3
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      type: https
-      path: "/src/puppet/modules"
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.0.1
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.4.0
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.0.1
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.0.1
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.1.0
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.0.3
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp-2.1.0
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.2.1
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.5.0
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.1.0
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-1.0.1
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.11.0
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.2.0
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-1.6.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-1.4.1
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-1.4.0
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-3.10.0
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-4.8.0
-    puppetlabs-stdlib:
-      ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-4.13.1
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.0.1
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      type: https
-      path: "/src/puppet/modules"
-      tag: 4.0.0
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.2
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.0.1
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.1
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      type: https
-      path: "/src/puppet/modules"
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.0.2
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.1.1
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.0.0
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.0.1
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.2
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.1
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.1
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-0.2.2
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.0.1
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      type: https
-      path: "/src/puppet/modules"
-      tag: 3.0.0
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      type: https
-      path: "/src/puppet/modules"
-      tag: 5.0.2
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      type: https
-      path: "/src/puppet/modules"
-      tag: 5.0.0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.2
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      type: https
-      path: "/src/puppet/modules"
-      tag: 2.0.0
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.2
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.2
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      type: https
-      path: "/src/puppet/modules"
-      tag: 5.0.1
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.3.0
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-5.1.2
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.1
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.0.2
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      type: https
-      path: "/src/puppet/modules"
-      tag: 2.0.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      type: https
-      path: "/src/puppet/modules"
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      type: https
-      path: "/src/puppet/modules"
-      tag: 4.1.0-post1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      type: https
-      path: "/src/puppet/modules"
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.0.1
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.2
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.3
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-      type: https
-      path: "/src/puppet/modules"
-      tag: 3.3.1
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      type: https
-      path: "/src/puppet/modules"
-      tag: 2.0.3
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.1.0
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      type: https
-      path: "/src/puppet/modules"
-      tag: 5.0.1
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      type: https
-      path: "/src/puppet/modules"
-      tag: 3.2.0
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.1.0
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      type: https
-      path: "/src/puppet/modules"
-      tag: 1.0.0
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.0.1
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.0
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      type: https
-      path: "/src/puppet/modules"
-      tag: 6.0.1
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      type: https
-      path: "/src/puppet/modules"
-      tag: 7.0.0
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      type: https
-      path: "/src/puppet/modules"
-      tag: 4.0.1
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      type: https
-      path: "/src/puppet/modules"
-      tag: 0.1.0
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      type: https
-      path: "/src/puppet/modules"
-      tag: simp6.0.0-2.0.0
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+        type: https
+        path: "/src"
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.2
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+        type: https
+        path: "/src/rubygems"
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+        type: https
+        path: "/src/puppet/modules"
+        tag: v2.5.0-34-g6d426d5
+      puppet-kmod:
+        ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.1.0
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp-0.11.0
+      puppet-logstash:
+        ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
+        type: https
+        path: "/src/puppet/modules"
+        tag: 5.0.3
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        type: https
+        path: "/src/puppet/modules"
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.0.1
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.1.3
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.4.0
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.0.1
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.0.1
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.1.0
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.0.3
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp-2.1.0
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.2.1
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.5.0
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.1.0
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-1.0.1
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.11.0
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.2.0
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-1.6.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-1.4.1
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-1.4.0
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-3.10.0
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-4.8.0
+      puppetlabs-stdlib:
+        ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-4.13.1
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.0.1
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        type: https
+        path: "/src/puppet/modules"
+        tag: 4.0.0
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.2
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.0.1
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.1
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        type: https
+        path: "/src/puppet/modules"
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.0.2
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.1.1
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.0.0
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.0.1
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.2
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.1
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.1
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-0.2.2
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.0.1
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        type: https
+        path: "/src/puppet/modules"
+        tag: 3.0.0
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        type: https
+        path: "/src/puppet/modules"
+        tag: 5.0.2
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        type: https
+        path: "/src/puppet/modules"
+        tag: 5.0.0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.2
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        type: https
+        path: "/src/puppet/modules"
+        tag: 2.0.0
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.2
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.2
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        type: https
+        path: "/src/puppet/modules"
+        tag: 5.0.1
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.3.0
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-5.1.2
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.1
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.0.2
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        type: https
+        path: "/src/puppet/modules"
+        tag: 2.0.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        type: https
+        path: "/src/puppet/modules"
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        type: https
+        path: "/src/puppet/modules"
+        tag: 4.1.0-post1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        type: https
+        path: "/src/puppet/modules"
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.0.1
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.2
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.3
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+        type: https
+        path: "/src/puppet/modules"
+        tag: 3.3.1
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        type: https
+        path: "/src/puppet/modules"
+        tag: 2.0.3
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.1.0
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        type: https
+        path: "/src/puppet/modules"
+        tag: 5.0.1
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        type: https
+        path: "/src/puppet/modules"
+        tag: 3.2.0
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.1.0
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        type: https
+        path: "/src/puppet/modules"
+        tag: 1.0.0
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.0.1
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.0
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        type: https
+        path: "/src/puppet/modules"
+        tag: 6.0.1
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        type: https
+        path: "/src/puppet/modules"
+        tag: 7.0.0
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        type: https
+        path: "/src/puppet/modules"
+        tag: 4.0.1
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        type: https
+        path: "/src/puppet/modules"
+        tag: 0.1.0
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        type: https
+        path: "/src/puppet/modules"
+        tag: simp6.0.0-2.0.0
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.0.0-1.yaml
+++ b/v1/releases/6.0.0-1.yaml
@@ -1,215 +1,220 @@
 ---
 releases:
   6.0.0-1:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
-    puppet-elasticsearch:
-      ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
-    puppet-logstash:
-      ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-    puppetlabs-stdlib:
-      ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        ref: 0d69a96e8d0d3a08da0d5f476c733134df4fb9ee
+      puppet-elasticsearch:
+        ref: dc6d3fab6ace62701aa3de6e4bb868e24fef0553
+      puppet-logstash:
+        ref: f475deaeb6120abc4c56c27cd3ab1ce808391517
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+      puppetlabs-stdlib:
+        ref: 7507af555361b2dcba8ed6189dc54c21e64ea031
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.1.0-0.yaml
+++ b/v1/releases/6.1.0-0.yaml
@@ -1,327 +1,332 @@
 ---
 releases:
   6.1.0-0:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      tag: 6.0.2
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-    puppet-elasticsearch:
-      tag: 5.2.0
-    puppet-logstash:
-      tag: 5.2.1
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      tag: simp6.0.0-2.0.1
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      tag: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      tag: simp6.0.0-2.4.0
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      tag: simp6.0.0-2.0.1
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      tag: simp6.0.0-2.0.1
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      tag: simp6.0.0-2.1.0
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      tag: simp6.0.0-2.0.3
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      tag: simp-2.1.0
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      tag: simp6.0.0-2.2.1
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      tag: simp6.0.0-2.5.0
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      tag: simp6.0.0-2.1.0
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      tag: simp6.0.0-1.0.1
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      tag: 1.11.0
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      tag: simp6.0.0-2.2.0
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      tag: simp6.0.0-1.6.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      tag: simp6.0.0-1.4.1
-    puppetlabs-puppet_authorization:
-      ref: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      tag: simp6.0.0-1.4.0
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      tag: simp6.0.0-3.10.0
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      tag: simp6.0.0-4.8.0
-    puppetlabs-stdlib:
-      tag: 4.19.0
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      tag: 1.0.1
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      tag: 4.0.0
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      tag: 6.0.0
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      tag: 0.0.2
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      tag: 7.0.1
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      tag: 6.0.0
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      tag: 0.0.1
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      tag: 6.0.0
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      tag: 6.0.0
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      tag: 1.0.2
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      tag: 0.1.1
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      tag: 7.0.0
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      tag: 7.0.1
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      tag: 6.0.2
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      tag: 0.0.1
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      tag: 6.0.1
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      tag: 0.0.1
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      tag: 6.0.0
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      tag: simp6.0.0-0.2.2
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      tag: 7.0.1
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      tag: 3.0.0
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      tag: 5.0.2
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      tag: 6.0.0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      tag: 6.0.0
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      tag: 5.0.0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      tag: 6.0.1
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      tag: 6.0.1
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      tag: 6.0.2
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      tag: 6.0.1
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      tag: 2.0.0
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      tag: 6.0.2
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      tag: 6.0.1
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      tag: 6.0.2
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      tag: 6.0.0
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      tag: 6.0.0
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      tag: 5.0.1
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      tag: 7.3.0
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      tag: simp6.0.0-5.1.2
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      tag: 0.0.1
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-      tag: 7.0.2
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      tag: 2.0.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      tag: 6.0.0
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      tag: 4.1.0-post1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      tag: 1.0.1
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      tag: 0.0.2
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      tag: 0.0.3
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-      tag: 3.3.1
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      tag: 2.0.3
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      tag: 6.1.0
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      tag: 6.0.1
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      tag: 6.0.1
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      tag: 5.0.1
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      tag: 6.0.0
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      tag: 3.2.0
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      tag: 0.1.0
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      tag: 6.0.0
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      tag: 6.0.0
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      tag: 1.0.0
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      tag: 0.0.1
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      tag: 6.0.0
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      tag: 6.0.1
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      tag: 7.0.0
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      tag: 4.0.1
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      tag: 0.1.0
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      tag: simp6.0.0-2.0.0
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        tag: 6.0.2
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+      puppet-elasticsearch:
+        tag: 5.2.0
+      puppet-logstash:
+        tag: 5.2.1
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        tag: simp6.0.0-2.0.1
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        tag: simp6.0.0-2.1.3
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        tag: simp6.0.0-2.4.0
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        tag: simp6.0.0-2.0.1
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        tag: simp6.0.0-2.0.1
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        tag: simp6.0.0-2.1.0
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        tag: simp6.0.0-2.0.3
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        tag: simp-2.1.0
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        tag: simp6.0.0-2.2.1
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        tag: simp6.0.0-2.5.0
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        tag: simp6.0.0-2.1.0
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        tag: simp6.0.0-1.0.1
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        tag: 1.11.0
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        tag: simp6.0.0-2.2.0
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        tag: simp6.0.0-1.6.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        tag: simp6.0.0-1.4.1
+      puppetlabs-puppet_authorization:
+        ref: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        tag: simp6.0.0-1.4.0
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        tag: simp6.0.0-3.10.0
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        tag: simp6.0.0-4.8.0
+      puppetlabs-stdlib:
+        tag: 4.19.0
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        tag: 1.0.1
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        tag: 4.0.0
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        tag: 6.0.0
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        tag: 0.0.2
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        tag: 7.0.1
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        tag: 6.0.0
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        tag: 0.0.1
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        tag: 6.0.0
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        tag: 6.0.0
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        tag: 1.0.2
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        tag: 0.1.1
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        tag: 7.0.0
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        tag: 7.0.1
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        tag: 6.0.2
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        tag: 0.0.1
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        tag: 6.0.1
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        tag: 0.0.1
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        tag: 6.0.0
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        tag: simp6.0.0-0.2.2
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        tag: 7.0.1
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        tag: 3.0.0
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        tag: 5.0.2
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        tag: 6.0.0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        tag: 6.0.0
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        tag: 5.0.0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        tag: 6.0.1
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        tag: 6.0.1
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        tag: 6.0.2
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        tag: 6.0.1
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        tag: 2.0.0
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        tag: 6.0.2
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        tag: 6.0.1
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        tag: 6.0.2
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        tag: 6.0.0
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        tag: 6.0.0
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        tag: 5.0.1
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        tag: 7.3.0
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        tag: simp6.0.0-5.1.2
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        tag: 0.0.1
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+        tag: 7.0.2
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        tag: 2.0.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        tag: 6.0.0
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        tag: 4.1.0-post1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        tag: 1.0.1
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        tag: 0.0.2
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        tag: 0.0.3
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+        tag: 3.3.1
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        tag: 2.0.3
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        tag: 6.1.0
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        tag: 6.0.1
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        tag: 6.0.1
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        tag: 5.0.1
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        tag: 6.0.0
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        tag: 3.2.0
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        tag: 0.1.0
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        tag: 6.0.0
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        tag: 6.0.0
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        tag: 1.0.0
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        tag: 0.0.1
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        tag: 6.0.0
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        tag: 6.0.1
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        tag: 7.0.0
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        tag: 4.0.1
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        tag: 0.1.0
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        tag: simp6.0.0-2.0.0
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.1.1.yaml
+++ b/v1/releases/6.1.1.yaml
@@ -1,327 +1,332 @@
 ---
 releases:
   6.1.1:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      tag: 6.0.2
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-    puppet-elasticsearch:
-      tag: 5.2.0
-    puppet-logstash:
-      tag: 5.2.1
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      tag: simp6.0.0-2.0.1
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      tag: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      tag: simp6.0.0-2.4.0
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      tag: simp6.0.0-2.0.1
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      tag: simp6.0.0-2.0.1
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      tag: simp6.0.0-2.1.0
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      tag: simp6.0.0-2.0.3
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      tag: simp-2.1.0
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      tag: simp6.0.0-2.2.1
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      tag: simp6.0.0-2.5.0
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      tag: simp6.0.0-2.1.0
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      tag: simp6.0.0-1.0.1
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      tag: 1.11.0
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      tag: simp6.0.0-2.2.0
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      tag: simp6.0.0-1.6.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      tag: simp6.0.0-1.4.1
-    puppetlabs-puppet_authorization:
-      ref: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      tag: simp6.0.0-1.4.0
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      tag: simp6.0.0-3.10.0
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      tag: simp6.0.0-4.8.0
-    puppetlabs-stdlib:
-      tag: 4.19.0
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      tag: 1.0.1
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      tag: 4.0.0
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      tag: 6.0.0
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      tag: 0.0.2
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      tag: 7.0.1
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      tag: 6.0.0
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      tag: 0.0.1
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      tag: 6.0.0
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      tag: 6.0.0
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      tag: 1.0.2
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      tag: 0.1.1
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      tag: 7.0.0
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      tag: 7.0.1
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      tag: 6.0.2
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      tag: 0.0.1
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      tag: 6.0.1
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      tag: 0.0.1
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      tag: 6.0.0
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      tag: simp6.0.0-0.2.2
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      tag: 7.0.1
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      tag: 3.0.0
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      tag: 5.0.2
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      tag: 6.0.0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      tag: 6.0.0
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      tag: 5.0.0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      tag: 6.0.1
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      tag: 6.0.1
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      tag: 6.0.2
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      tag: 6.0.1
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      tag: 2.0.0
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      tag: 6.0.2
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      tag: 6.0.1
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      tag: 6.0.2
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      tag: 6.0.0
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      tag: 6.0.0
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      tag: 5.0.1
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      tag: 7.3.0
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      tag: simp6.0.0-5.1.2
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      tag: 0.0.1
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-      tag: 7.0.2
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      tag: 2.0.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      tag: 6.0.0
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      tag: 4.1.0-post1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      tag: 1.0.1
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      tag: 0.0.2
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      tag: 0.0.3
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-      tag: 3.3.1
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      tag: 2.0.3
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      tag: 6.1.0
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      tag: 6.0.1
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      tag: 6.0.1
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      tag: 5.0.1
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      tag: 6.0.0
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      tag: 3.2.0
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      tag: 0.1.0
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      tag: 6.0.0
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      tag: 6.0.0
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      tag: 1.0.0
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      tag: 0.0.1
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      tag: 6.0.0
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      tag: 6.0.1
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      tag: 7.0.0
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      tag: 4.0.1
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      tag: 0.1.0
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      tag: simp6.0.0-2.0.0
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        tag: 6.0.2
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+      puppet-elasticsearch:
+        tag: 5.2.0
+      puppet-logstash:
+        tag: 5.2.1
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        tag: simp6.0.0-2.0.1
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        tag: simp6.0.0-2.1.3
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        tag: simp6.0.0-2.4.0
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        tag: simp6.0.0-2.0.1
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        tag: simp6.0.0-2.0.1
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        tag: simp6.0.0-2.1.0
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        tag: simp6.0.0-2.0.3
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        tag: simp-2.1.0
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        tag: simp6.0.0-2.2.1
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        tag: simp6.0.0-2.5.0
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        tag: simp6.0.0-2.1.0
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        tag: simp6.0.0-1.0.1
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        tag: 1.11.0
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        tag: simp6.0.0-2.2.0
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        tag: simp6.0.0-1.6.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        tag: simp6.0.0-1.4.1
+      puppetlabs-puppet_authorization:
+        ref: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        tag: simp6.0.0-1.4.0
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        tag: simp6.0.0-3.10.0
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        tag: simp6.0.0-4.8.0
+      puppetlabs-stdlib:
+        tag: 4.19.0
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        tag: 1.0.1
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        tag: 4.0.0
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        tag: 6.0.0
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        tag: 0.0.2
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        tag: 7.0.1
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        tag: 6.0.0
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        tag: 0.0.1
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        tag: 6.0.0
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        tag: 6.0.0
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        tag: 1.0.2
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        tag: 0.1.1
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        tag: 7.0.0
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        tag: 7.0.1
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        tag: 6.0.2
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        tag: 0.0.1
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        tag: 6.0.1
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        tag: 0.0.1
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        tag: 6.0.0
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        tag: simp6.0.0-0.2.2
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        tag: 7.0.1
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        tag: 3.0.0
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        tag: 5.0.2
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        tag: 6.0.0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        tag: 6.0.0
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        tag: 5.0.0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        tag: 6.0.1
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        tag: 6.0.1
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        tag: 6.0.2
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        tag: 6.0.1
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        tag: 2.0.0
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        tag: 6.0.2
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        tag: 6.0.1
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        tag: 6.0.2
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        tag: 6.0.0
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        tag: 6.0.0
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        tag: 5.0.1
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        tag: 7.3.0
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        tag: simp6.0.0-5.1.2
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        tag: 0.0.1
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+        tag: 7.0.2
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        tag: 2.0.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        tag: 6.0.0
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        tag: 4.1.0-post1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        tag: 1.0.1
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        tag: 0.0.2
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        tag: 0.0.3
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+        tag: 3.3.1
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        tag: 2.0.3
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        tag: 6.1.0
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        tag: 6.0.1
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        tag: 6.0.1
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        tag: 5.0.1
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        tag: 6.0.0
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        tag: 3.2.0
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        tag: 0.1.0
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        tag: 6.0.0
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        tag: 6.0.0
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        tag: 1.0.0
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        tag: 0.0.1
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        tag: 6.0.0
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        tag: 6.0.1
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        tag: 7.0.0
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        tag: 4.0.1
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        tag: 0.1.0
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        tag: simp6.0.0-2.0.0
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.1.2.yaml
+++ b/v1/releases/6.1.2.yaml
@@ -1,327 +1,332 @@
 ---
 releases:
   6.1.2:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      tag: 6.0.2
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-    puppet-elasticsearch:
-      tag: 5.2.0
-    puppet-logstash:
-      tag: 5.2.1
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      tag: simp6.0.0-2.0.1
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      tag: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      tag: simp6.0.0-2.4.0
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      tag: simp6.0.0-2.0.1
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      tag: simp6.0.0-2.0.1
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      tag: simp6.0.0-2.1.0
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      tag: simp6.0.0-2.0.3
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      tag: simp-2.1.0
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      tag: simp6.0.0-2.2.1
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      tag: simp6.0.0-2.5.0
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      tag: simp6.0.0-2.1.0
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      tag: simp6.0.0-1.0.1
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      tag: 1.11.0
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      tag: simp6.0.0-2.2.0
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      tag: simp6.0.0-1.6.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      tag: simp6.0.0-1.4.1
-    puppetlabs-puppet_authorization:
-      ref: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      tag: simp6.0.0-1.4.0
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      tag: simp6.0.0-3.10.0
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      tag: simp6.0.0-4.8.0
-    puppetlabs-stdlib:
-      tag: 4.19.0
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      tag: 1.0.1
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      tag: 4.0.0
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      tag: 6.0.0
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      tag: 0.0.2
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      tag: 7.0.1
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      tag: 6.0.0
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      tag: 0.0.1
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      tag: 6.0.0
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      tag: 6.0.0
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      tag: 1.0.2
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      tag: 0.1.1
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      tag: 7.0.0
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      tag: 7.0.1
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      tag: 6.0.2
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      tag: 0.0.1
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      tag: 6.0.1
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      tag: 0.0.1
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      tag: 6.0.0
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      tag: simp6.0.0-0.2.2
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      tag: 7.0.1
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      tag: 3.0.0
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      tag: 5.0.2
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      tag: 6.0.0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      tag: 6.0.0
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      tag: 5.0.0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      tag: 6.0.1
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      tag: 6.0.1
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      tag: 6.0.2
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      tag: 6.0.1
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      tag: 2.0.0
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      tag: 6.0.2
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      tag: 6.0.1
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      tag: 6.0.2
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      tag: 6.0.0
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      tag: 6.0.0
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      tag: 5.0.1
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      tag: 7.3.0
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      tag: simp6.0.0-5.1.2
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      tag: 0.0.1
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-      tag: 7.0.2
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      tag: 2.0.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      tag: 6.0.0
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      tag: 4.1.0-post1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      tag: 1.0.1
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      tag: 0.0.2
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      tag: 0.0.3
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-      tag: 3.3.1
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      tag: 2.0.3
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      tag: 6.1.0
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      tag: 6.0.1
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      tag: 6.0.1
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      tag: 5.0.1
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      tag: 6.0.0
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      tag: 3.2.0
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      tag: 0.1.0
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      tag: 6.0.0
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      tag: 6.0.0
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      tag: 1.0.0
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      tag: 0.0.1
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      tag: 6.0.0
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      tag: 6.0.1
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      tag: 7.0.0
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      tag: 4.0.1
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      tag: 0.1.0
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      tag: simp6.0.0-2.0.0
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        tag: 6.0.2
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+      puppet-elasticsearch:
+        tag: 5.2.0
+      puppet-logstash:
+        tag: 5.2.1
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        tag: simp6.0.0-2.0.1
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        tag: simp6.0.0-2.1.3
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        tag: simp6.0.0-2.4.0
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        tag: simp6.0.0-2.0.1
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        tag: simp6.0.0-2.0.1
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        tag: simp6.0.0-2.1.0
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        tag: simp6.0.0-2.0.3
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        tag: simp-2.1.0
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        tag: simp6.0.0-2.2.1
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        tag: simp6.0.0-2.5.0
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        tag: simp6.0.0-2.1.0
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        tag: simp6.0.0-1.0.1
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        tag: 1.11.0
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        tag: simp6.0.0-2.2.0
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        tag: simp6.0.0-1.6.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        tag: simp6.0.0-1.4.1
+      puppetlabs-puppet_authorization:
+        ref: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        tag: simp6.0.0-1.4.0
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        tag: simp6.0.0-3.10.0
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        tag: simp6.0.0-4.8.0
+      puppetlabs-stdlib:
+        tag: 4.19.0
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        tag: 1.0.1
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        tag: 4.0.0
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        tag: 6.0.0
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        tag: 0.0.2
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        tag: 7.0.1
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        tag: 6.0.0
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        tag: 0.0.1
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        tag: 6.0.0
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        tag: 6.0.0
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        tag: 1.0.2
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        tag: 0.1.1
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        tag: 7.0.0
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        tag: 7.0.1
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        tag: 6.0.2
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        tag: 0.0.1
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        tag: 6.0.1
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        tag: 0.0.1
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        tag: 6.0.0
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        tag: simp6.0.0-0.2.2
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        tag: 7.0.1
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        tag: 3.0.0
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        tag: 5.0.2
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        tag: 6.0.0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        tag: 6.0.0
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        tag: 5.0.0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        tag: 6.0.1
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        tag: 6.0.1
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        tag: 6.0.2
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        tag: 6.0.1
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        tag: 2.0.0
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        tag: 6.0.2
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        tag: 6.0.1
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        tag: 6.0.2
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        tag: 6.0.0
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        tag: 6.0.0
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        tag: 5.0.1
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        tag: 7.3.0
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        tag: simp6.0.0-5.1.2
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        tag: 0.0.1
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+        tag: 7.0.2
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        tag: 2.0.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        tag: 6.0.0
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        tag: 4.1.0-post1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        tag: 1.0.1
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        tag: 0.0.2
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        tag: 0.0.3
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+        tag: 3.3.1
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        tag: 2.0.3
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        tag: 6.1.0
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        tag: 6.0.1
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        tag: 6.0.1
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        tag: 5.0.1
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        tag: 6.0.0
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        tag: 3.2.0
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        tag: 0.1.0
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        tag: 6.0.0
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        tag: 6.0.0
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        tag: 1.0.0
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        tag: 0.0.1
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        tag: 6.0.0
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        tag: 6.0.1
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        tag: 7.0.0
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        tag: 4.0.1
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        tag: 0.1.0
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        tag: simp6.0.0-2.0.0
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.1.3.yaml
+++ b/v1/releases/6.1.3.yaml
@@ -1,327 +1,332 @@
 ---
 releases:
   6.1.3:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      tag: 6.0.2
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-    puppet-elasticsearch:
-      tag: 5.2.0
-    puppet-logstash:
-      tag: 5.2.1
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      tag: simp6.0.0-2.0.1
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      tag: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      tag: simp6.0.0-2.4.0
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      tag: simp6.0.0-2.0.1
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      tag: simp6.0.0-2.0.1
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      tag: simp6.0.0-2.1.0
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      tag: simp6.0.0-2.0.3
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      tag: simp-2.1.0
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      tag: simp6.0.0-2.2.1
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      tag: simp6.0.0-2.5.0
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      tag: simp6.0.0-2.1.0
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      tag: simp6.0.0-1.0.1
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      tag: 1.11.0
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      tag: simp6.0.0-2.2.0
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      tag: simp6.0.0-1.6.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      tag: simp6.0.0-1.4.1
-    puppetlabs-puppet_authorization:
-      ref: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      tag: simp6.0.0-1.4.0
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      tag: simp6.0.0-3.10.0
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      tag: simp6.0.0-4.8.0
-    puppetlabs-stdlib:
-      tag: 4.19.0
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      tag: 1.0.1
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      tag: 4.0.0
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      tag: 6.0.0
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      tag: 0.0.2
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      tag: 7.0.1
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      tag: 6.0.0
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      tag: 0.0.1
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      tag: 6.0.0
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      tag: 6.0.0
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      tag: 1.0.2
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      tag: 0.1.1
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      tag: 7.0.0
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      tag: 7.0.1
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      tag: 6.0.2
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      tag: 0.0.1
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      tag: 6.0.1
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      tag: 0.0.1
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      tag: 6.0.0
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      tag: simp6.0.0-0.2.2
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      tag: 7.0.1
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      tag: 3.0.0
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      tag: 5.0.2
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      tag: 6.0.0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      tag: 6.0.0
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      tag: 5.0.0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      tag: 6.0.1
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      tag: 6.0.1
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      tag: 6.0.2
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      tag: 6.0.1
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      tag: 2.0.0
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      tag: 6.0.2
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      tag: 6.0.1
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      tag: 6.0.2
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      tag: 6.0.0
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      tag: 6.0.0
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      tag: 5.0.1
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      tag: 7.3.0
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      tag: simp6.0.0-5.1.2
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      tag: 0.0.1
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-      tag: 7.0.2
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      tag: 2.0.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      tag: 6.0.0
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      tag: 4.1.0-post1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      tag: 1.0.1
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      tag: 0.0.2
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      tag: 0.0.3
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-      tag: 3.3.1
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      tag: 2.0.3
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      tag: 6.1.0
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      tag: 6.0.1
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      tag: 6.0.1
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      tag: 5.0.1
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      tag: 6.0.0
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      tag: 3.2.0
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      tag: 0.1.0
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      tag: 6.0.0
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      tag: 6.0.0
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      tag: 1.0.0
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      tag: 0.0.1
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      tag: 6.0.0
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      tag: 6.0.1
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      tag: 7.0.0
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      tag: 4.0.1
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      tag: 0.1.0
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      tag: simp6.0.0-2.0.0
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        tag: 6.0.2
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+      puppet-elasticsearch:
+        tag: 5.2.0
+      puppet-logstash:
+        tag: 5.2.1
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        tag: simp6.0.0-2.0.1
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        tag: simp6.0.0-2.1.3
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        tag: simp6.0.0-2.4.0
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        tag: simp6.0.0-2.0.1
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        tag: simp6.0.0-2.0.1
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        tag: simp6.0.0-2.1.0
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        tag: simp6.0.0-2.0.3
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        tag: simp-2.1.0
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        tag: simp6.0.0-2.2.1
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        tag: simp6.0.0-2.5.0
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        tag: simp6.0.0-2.1.0
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        tag: simp6.0.0-1.0.1
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        tag: 1.11.0
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        tag: simp6.0.0-2.2.0
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        tag: simp6.0.0-1.6.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        tag: simp6.0.0-1.4.1
+      puppetlabs-puppet_authorization:
+        ref: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        tag: simp6.0.0-1.4.0
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        tag: simp6.0.0-3.10.0
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        tag: simp6.0.0-4.8.0
+      puppetlabs-stdlib:
+        tag: 4.19.0
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        tag: 1.0.1
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        tag: 4.0.0
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        tag: 6.0.0
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        tag: 0.0.2
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        tag: 7.0.1
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        tag: 6.0.0
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        tag: 0.0.1
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        tag: 6.0.0
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        tag: 6.0.0
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        tag: 1.0.2
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        tag: 0.1.1
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        tag: 7.0.0
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        tag: 7.0.1
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        tag: 6.0.2
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        tag: 0.0.1
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        tag: 6.0.1
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        tag: 0.0.1
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        tag: 6.0.0
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        tag: simp6.0.0-0.2.2
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        tag: 7.0.1
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        tag: 3.0.0
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        tag: 5.0.2
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        tag: 6.0.0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        tag: 6.0.0
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        tag: 5.0.0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        tag: 6.0.1
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        tag: 6.0.1
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        tag: 6.0.2
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        tag: 6.0.1
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        tag: 2.0.0
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        tag: 6.0.2
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        tag: 6.0.1
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        tag: 6.0.2
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        tag: 6.0.0
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        tag: 6.0.0
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        tag: 5.0.1
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        tag: 7.3.0
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        tag: simp6.0.0-5.1.2
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        tag: 0.0.1
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+        tag: 7.0.2
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        tag: 2.0.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        tag: 6.0.0
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        tag: 4.1.0-post1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        tag: 1.0.1
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        tag: 0.0.2
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        tag: 0.0.3
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+        tag: 3.3.1
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        tag: 2.0.3
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        tag: 6.1.0
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        tag: 6.0.1
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        tag: 6.0.1
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        tag: 5.0.1
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        tag: 6.0.0
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        tag: 3.2.0
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        tag: 0.1.0
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        tag: 6.0.0
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        tag: 6.0.0
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        tag: 1.0.0
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        tag: 0.0.1
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        tag: 6.0.0
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        tag: 6.0.1
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        tag: 7.0.0
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        tag: 4.0.1
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        tag: 0.1.0
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        tag: simp6.0.0-2.0.0
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.1.4.yaml
+++ b/v1/releases/6.1.4.yaml
@@ -1,327 +1,332 @@
 ---
 releases:
   6.1.4:
-    simp-doc:
-      ref: 79c18f732f6c73b8bff21809c639771a892722f2
-    pupmod-simp-rsync:
-      ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
-      tag: 6.0.2
-    simp-rsync:
-      ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
-    simp-adapter:
-      ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
-    simp-environment:
-      ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
-    simp-gpgkeys:
-      ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
-    simp-utils:
-      ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
-    rubygem-simp-cli:
-      ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
-    puppet-grafana:
-      ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
-    puppet-kmod:
-      tag: 2.2.0
-    puppet-elasticsearch:
-      tag: 5.2.0
-    puppet-logstash:
-      tag: 5.2.1
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: 66f17fabef214dc830b1692123c99990d03d4b6b
-      tag: simp6.0.0-2.0.1
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 72fccf10b532f06fc81cf491614e7119c72ee981
-      tag: simp6.0.0-2.1.3
-    augeasproviders_grub:
-      ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
-      tag: simp6.0.0-2.4.0
-    augeasproviders_mounttab:
-      ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
-      tag: simp6.0.0-2.0.1
-    augeasproviders_nagios:
-      ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
-      tag: simp6.0.0-2.0.1
-    augeasproviders_pam:
-      ref: a9481948712e2e2951162cbcf5dda7003d54cf16
-      tag: simp6.0.0-2.1.0
-    augeasproviders_postgresql:
-      ref: 6b70535febce71e6d54c04e065deebd590491083
-      tag: simp6.0.0-2.0.3
-    augeasproviders_puppet:
-      ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
-      tag: simp-2.1.0
-    augeasproviders_shellvar:
-      ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
-      tag: simp6.0.0-2.2.1
-    augeasproviders_ssh:
-      ref: a8b72a482a37fe86827e41659a7d8753a309cb07
-      tag: simp6.0.0-2.5.0
-    augeasproviders_sysctl:
-      ref: 4425603e3c95e086596c9e4ab41813b408f99785
-      tag: simp6.0.0-2.1.0
-    puppet-gpasswd:
-      ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
-      tag: simp6.0.0-1.0.1
-    puppetlabs-apache:
-      ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
-      tag: 1.11.0
-    puppetlabs-concat:
-      ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
-      tag: simp6.0.0-2.2.0
-    puppetlabs-inifile:
-      ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
-      tag: simp6.0.0-1.6.0
-    puppetlabs-java:
-      ref: e36f6ce7603d2c14d391d368de171b0828437617
-      tag: simp-1.6.0-post1
-    puppetlabs-java_ks:
-      ref: ef5ac6157f6ee90917af606b25010f31c906ed92
-      tag: simp6.0.0-1.4.1
-    puppetlabs-puppet_authorization:
-      ref: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
-      tag: simp6.0.0-1.4.0
-    puppetlabs-mysql:
-      ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
-      tag: simp6.0.0-3.10.0
-    puppetlabs-postgresql:
-      ref: d022a56b28b2174456fc0f6adc51a4b54493afad
-      tag: simp6.0.0-4.8.0
-    puppetlabs-stdlib:
-      tag: 4.19.0
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
-      tag: simp6.0.0-3.3.0
-    pupmod-simp-acpid:
-      ref: 66ec8df52c867252a742c8023ddf176105147dc3
-      tag: 1.0.1
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      tag: 4.0.0
-    pupmod-simp-aide:
-      ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
-      tag: 6.0.0
-    pupmod-simp-at:
-      ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
-      tag: 0.0.2
-    pupmod-simp-auditd:
-      ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
-      tag: 7.0.1
-    pupmod-simp-autofs:
-      ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
-      tag: 6.0.0
-    pupmod-simp-chkrootkit:
-      ref: 9896b324489f1f615c48736aed18f47c2bc86de8
-      tag: 0.0.1
-    pupmod-simp-clamav:
-      ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
-      tag: 6.0.0
-    pupmod-simp-compliance_markup:
-      ref: cadc444b001ef06f423dca141229cc91d043e932
-      tag: 2.0.1
-    pupmod-simp-cron:
-      ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
-      tag: 6.0.0
-    pupmod-simp-dirtycow:
-      ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
-      tag: 1.0.2
-    pupmod-simp-fips:
-      ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
-      tag: 0.1.1
-    pupmod-simp-freeradius:
-      ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
-      tag: 7.0.0
-    pupmod-simp-gdm:
-      ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
-      tag: 7.0.1
-    pupmod-simp-gnome:
-      ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
-      tag: 6.0.2
-    puppet-haveged:
-      ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
-      tag: 0.4.0
-    pupmod-simp-incron:
-      ref: 0faecbcf94c40c00662d70bae17640936816066e
-      tag: 0.0.1
-    pupmod-simp-iptables:
-      ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
-      tag: 6.0.1
-    pupmod-simp-issue:
-      ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
-      tag: 0.0.1
-    pupmod-simp-jenkins:
-      ref: b3b024b8246c8c4445c8b97404c994f7aada6384
-      tag: 6.0.0
-    pupmod-simp-journald:
-      ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
-      tag: simp6.0.0-0.2.2
-    pupmod-simp-krb5:
-      ref: '04941954129a52863368c3907f674aecd655271a'
-      tag: 7.0.1
-    pupmod-simp-libreswan:
-      ref: f850061118a8decfe62ea2fca25d222b33716cde
-      tag: 3.0.0
-    pupmod-simp-libvirt:
-      ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
-      tag: 5.0.2
-    pupmod-simp-logrotate:
-      ref: f078813e5394a7427216d73c44464bdfecbb07e0
-      tag: 6.0.0
-    pupmod-simp-mcafee:
-      ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
-      tag: 6.0.0
-    pupmod-simp-mcollective:
-      ref: 90ceda13854da0501e17f15602634d293bf54205
-      tag: simp-3.0.0
-    pupmod-simp-mozilla:
-      ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
-      tag: 5.0.0
-    pupmod-simp-named:
-      ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
-      tag: 6.0.1
-    pupmod-simp-network:
-      ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
-      tag: 6.0.1
-    pupmod-simp-nfs:
-      ref: e38c835d06e70520a7403b1dd69c0e7322285b81
-      tag: 6.0.2
-    pupmod-simp-ntpd:
-      ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
-      tag: 6.0.1
-    pupmod-simp-oddjob:
-      ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
-      tag: 2.0.0
-    pupmod-simp-simp_openldap:
-      ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
-      tag: 6.0.2
-    pupmod-simp-openscap:
-      ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
-      tag: 6.0.1
-    pupmod-simp-pam:
-      ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
-      tag: 6.0.2
-    pupmod-simp-pki:
-      ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
-      tag: 6.0.0
-    pupmod-simp-polkit:
-      ref: 91b57406f1053603bdb7c880aad824b7db906207
-      tag: 6.0.0
-    pupmod-simp-postfix:
-      ref: 6095591ca482fe57cf3525137a996290e7d03052
-      tag: 5.0.1
-    pupmod-simp-pupmod:
-      ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
-      tag: 7.3.0
-    puppetlabs-puppetdb:
-      ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
-      tag: simp6.0.0-5.1.2
-    pupmod-simp-resolv:
-      ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
-      tag: 0.0.1
-    pupmod-simp-rsyslog:
-      ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
-      tag: 7.0.2
-    pupmod-simp-selinux:
-      ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
-      tag: 2.0.2
-    pupmod-simp-simp:
-      ref: c0906fbf43f24cc9286429e8ee81035be7a36084
-      tag: 4.0.0
-    pupmod-simp-simpcat:
-      ref: 50deb1cecc783b28aed39e348da45cd212c37706
-      tag: 6.0.0
-    pupmod-simp-apache:
-      ref: beebf920ffd077e930d7705a7d470d1b22ff3304
-      tag: 1.11.0
-    pupmod-simp-simp_elasticsearch:
-      ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
-      tag: 4.1.0-post1
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
-      tag: 4.0.0
-    pupmod-simp-simp_options:
-      ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
-      tag: 1.0.1
-    pupmod-simp-simp_nfs:
-      ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
-      tag: 0.0.2
-    pupmod-simp-simp_rsyslog:
-      ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
-      tag: 0.0.3
-    pupmod-simp-simplib:
-      ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
-      tag: 3.3.1
-    pupmod-simp-site:
-      ref: 61327ae260572365cab6f778cd78f7769aa0d16e
-      tag: 2.0.3
-    pupmod-simp-ssh:
-      ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
-      tag: 6.1.0
-    pupmod-simp-sssd:
-      ref: b4b581657b5564fcece59014d96b04631b97d29a
-      tag: 6.0.1
-    pupmod-simp-stunnel:
-      ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
-      tag: 6.0.1
-    pupmod-simp-sudo:
-      ref: c94828d4840951c147c47e1136adb4ebaa92f555
-      tag: 5.0.1
-    pupmod-simp-sudosh:
-      ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
-      tag: 6.0.0
-    pupmod-simp-svckill:
-      ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
-      tag: 3.2.0
-    pupmod-simp-swap:
-      ref: 50cf9df5b2683584664cc88d74ec204494904142
-      tag: 0.1.0
-    pupmod-simp-tcpwrappers:
-      ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
-      tag: 6.0.0
-    pupmod-simp-tftpboot:
-      ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
-      tag: 6.0.0
-    pupmod-simp-tpm:
-      ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
-      tag: 1.0.0
-    pupmod-simp-tuned:
-      ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
-      tag: 0.0.1
-    pupmod-simp-upstart:
-      ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
-      tag: 6.0.0
-    pupmod-simp-vnc:
-      ref: 628b82476a97a091e673f72cadb89790bda77f30
-      tag: 6.0.1
-    pupmod-simp-vsftpd:
-      ref: 2833f39104be521143990f823824d69b58175b12
-      tag: 7.0.0
-    pupmod-simp-xinetd:
-      ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
-      tag: 4.0.1
-    pupmod-simp-useradd:
-      ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
-      tag: 0.1.0
-    puppet-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      tag: simp6.0.0-2.0.0
+    components:
+      simp-doc:
+        ref: 79c18f732f6c73b8bff21809c639771a892722f2
+      pupmod-simp-rsync:
+        ref: 5a065194f3369e29a7d3e092722ffd1bf9b8b822
+        tag: 6.0.2
+      simp-rsync:
+        ref: d03a15bfbdb7fd756b71e3e8e10b2fc7bbaa9f31
+      simp-adapter:
+        ref: 6d8208fb618bdb4e05e7696a76686bb8010dc6a1
+      simp-environment:
+        ref: 733d59986c7fd1cd87dcbc56a04ac82a0f5f2d30
+      simp-gpgkeys:
+        ref: 0cb94266ee5f02822cf6ed99df6d2597f39a26e6
+      simp-utils:
+        ref: 1828ea0d02f6c8a3277cffb0bbddc272afa9c93f
+      rubygem-simp-cli:
+        ref: 7e724639c8e036d651ec81d59ec67417c3c52eb9
+      puppet-grafana:
+        ref: 6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc
+      puppet-kmod:
+        tag: 2.2.0
+      puppet-elasticsearch:
+        tag: 5.2.0
+      puppet-logstash:
+        tag: 5.2.1
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: 66f17fabef214dc830b1692123c99990d03d4b6b
+        tag: simp6.0.0-2.0.1
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 72fccf10b532f06fc81cf491614e7119c72ee981
+        tag: simp6.0.0-2.1.3
+      augeasproviders_grub:
+        ref: b48597b56a48aa4cbae2f3866d32a67d6950c79b
+        tag: simp6.0.0-2.4.0
+      augeasproviders_mounttab:
+        ref: 670e8eb3df1297735da50d1ff5ec10c547acf00c
+        tag: simp6.0.0-2.0.1
+      augeasproviders_nagios:
+        ref: 4af1337ecbedfd1f8e79084c919b25a25b3f7d62
+        tag: simp6.0.0-2.0.1
+      augeasproviders_pam:
+        ref: a9481948712e2e2951162cbcf5dda7003d54cf16
+        tag: simp6.0.0-2.1.0
+      augeasproviders_postgresql:
+        ref: 6b70535febce71e6d54c04e065deebd590491083
+        tag: simp6.0.0-2.0.3
+      augeasproviders_puppet:
+        ref: bb3310e60ddfeddc9ab2b45f05066e44ff2b942e
+        tag: simp-2.1.0
+      augeasproviders_shellvar:
+        ref: 455780660018a7f8bccfedb0ec2d6aad4c864caa
+        tag: simp6.0.0-2.2.1
+      augeasproviders_ssh:
+        ref: a8b72a482a37fe86827e41659a7d8753a309cb07
+        tag: simp6.0.0-2.5.0
+      augeasproviders_sysctl:
+        ref: 4425603e3c95e086596c9e4ab41813b408f99785
+        tag: simp6.0.0-2.1.0
+      puppet-gpasswd:
+        ref: 04431f902da8b20527e1cb5eb98ec6f4fefd6429
+        tag: simp6.0.0-1.0.1
+      puppetlabs-apache:
+        ref: e267d693abab94f68e3e6a9c1c445e9db83dc070
+        tag: 1.11.0
+      puppetlabs-concat:
+        ref: 5eadf453a12a3df723380de1b80a2edc9ed10956
+        tag: simp6.0.0-2.2.0
+      puppetlabs-inifile:
+        ref: 252ab552f4bf57d1099c2c2f5578f602caa7b1a5
+        tag: simp6.0.0-1.6.0
+      puppetlabs-java:
+        ref: e36f6ce7603d2c14d391d368de171b0828437617
+        tag: simp-1.6.0-post1
+      puppetlabs-java_ks:
+        ref: ef5ac6157f6ee90917af606b25010f31c906ed92
+        tag: simp6.0.0-1.4.1
+      puppetlabs-puppet_authorization:
+        ref: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ac521566a31a5ba6aca9c6fe3f30c57dd5cf7449
+        tag: simp6.0.0-1.4.0
+      puppetlabs-mysql:
+        ref: 9442272f5654b10d1ce33559ebb73d45ff23a128
+        tag: simp6.0.0-3.10.0
+      puppetlabs-postgresql:
+        ref: d022a56b28b2174456fc0f6adc51a4b54493afad
+        tag: simp6.0.0-4.8.0
+      puppetlabs-stdlib:
+        tag: 4.19.0
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: 9344a1d094313b7d94e1ee4da4be9bda441c2708
+        tag: simp6.0.0-3.3.0
+      pupmod-simp-acpid:
+        ref: 66ec8df52c867252a742c8023ddf176105147dc3
+        tag: 1.0.1
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        tag: 4.0.0
+      pupmod-simp-aide:
+        ref: 57a04d9f6e179caddfc103ee5da2ccc9282ded2e
+        tag: 6.0.0
+      pupmod-simp-at:
+        ref: 35bf42043b4b664a61b6b6b6d851ea1ee3b14160
+        tag: 0.0.2
+      pupmod-simp-auditd:
+        ref: 01d15c8d79ce9243c682863b3268200e3f6ee50a
+        tag: 7.0.1
+      pupmod-simp-autofs:
+        ref: d44e2c10cd4ecfc12afd0d3e4ae6ba7a9a7d3787
+        tag: 6.0.0
+      pupmod-simp-chkrootkit:
+        ref: 9896b324489f1f615c48736aed18f47c2bc86de8
+        tag: 0.0.1
+      pupmod-simp-clamav:
+        ref: c0e603c9af7ef72c3657a759ac450d2682b2fa64
+        tag: 6.0.0
+      pupmod-simp-compliance_markup:
+        ref: cadc444b001ef06f423dca141229cc91d043e932
+        tag: 2.0.1
+      pupmod-simp-cron:
+        ref: 3813e45a67c21ee35f1afbe24f6783573d4f9f0a
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: 178a113b3e5e5d4f9c4e6846a5500e18a0428eaf
+        tag: 6.0.0
+      pupmod-simp-dirtycow:
+        ref: e6191625e791d711f72eaf9ed4fb8e54c80a5968
+        tag: 1.0.2
+      pupmod-simp-fips:
+        ref: bde5e71939f7e3c1801d44bb2df825ccef6f1a09
+        tag: 0.1.1
+      pupmod-simp-freeradius:
+        ref: c602ce9f0ed1957d48514a0cd37257bccd903c0b
+        tag: 7.0.0
+      pupmod-simp-gdm:
+        ref: b50ca2bb9a3482620379b747736e9ba0b3bf3084
+        tag: 7.0.1
+      pupmod-simp-gnome:
+        ref: e706e2b2e22cecdca86d2ee48143a1c607a486df
+        tag: 6.0.2
+      puppet-haveged:
+        ref: d0e335efbccfd8e12f1ad2b70855df21a71aa7a3
+        tag: 0.4.0
+      pupmod-simp-incron:
+        ref: 0faecbcf94c40c00662d70bae17640936816066e
+        tag: 0.0.1
+      pupmod-simp-iptables:
+        ref: 0df308fdfd92d9bbff3f90574955ca7e612cf5ff
+        tag: 6.0.1
+      pupmod-simp-issue:
+        ref: 31fd9b22d3085d1c34d4d208d73b23a8094fc4ab
+        tag: 0.0.1
+      pupmod-simp-jenkins:
+        ref: b3b024b8246c8c4445c8b97404c994f7aada6384
+        tag: 6.0.0
+      pupmod-simp-journald:
+        ref: 0a6df1389b58ac787f3339a7f6ac3d1cdf56b9b9
+        tag: simp6.0.0-0.2.2
+      pupmod-simp-krb5:
+        ref: '04941954129a52863368c3907f674aecd655271a'
+        tag: 7.0.1
+      pupmod-simp-libreswan:
+        ref: f850061118a8decfe62ea2fca25d222b33716cde
+        tag: 3.0.0
+      pupmod-simp-libvirt:
+        ref: 6b3f491f14ba2a05287d80578976d7f568b0c3c6
+        tag: 5.0.2
+      pupmod-simp-logrotate:
+        ref: f078813e5394a7427216d73c44464bdfecbb07e0
+        tag: 6.0.0
+      pupmod-simp-mcafee:
+        ref: 6dfe22cbbf524971e21d1af5888656ad8d215091
+        tag: 6.0.0
+      pupmod-simp-mcollective:
+        ref: 90ceda13854da0501e17f15602634d293bf54205
+        tag: simp-3.0.0
+      pupmod-simp-mozilla:
+        ref: e2034e3ab42f2cee3b4a6e0462f64890adcabeb0
+        tag: 5.0.0
+      pupmod-simp-named:
+        ref: 7f4d09657bb4de03c73efaa0e87c6a9047b99c95
+        tag: 6.0.1
+      pupmod-simp-network:
+        ref: 328c9780c946524ff7e6fe4396c5df4e2cea66b5
+        tag: 6.0.1
+      pupmod-simp-nfs:
+        ref: e38c835d06e70520a7403b1dd69c0e7322285b81
+        tag: 6.0.2
+      pupmod-simp-ntpd:
+        ref: 916e56bd6c30e7d1fa00c35cf1b699848bde9bfe
+        tag: 6.0.1
+      pupmod-simp-oddjob:
+        ref: 0c79577630e86b6e2859738a04d65e4489ed29cd
+        tag: 2.0.0
+      pupmod-simp-simp_openldap:
+        ref: 0adc282a69b3d016049f8146578dff47cd5ef3d5
+        tag: 6.0.2
+      pupmod-simp-openscap:
+        ref: 9c26e36c57a9ad0451bb0a94440e0cfd62e77179
+        tag: 6.0.1
+      pupmod-simp-pam:
+        ref: 40a92d652ecb700674dc12a7bc4d6a3914eb0a27
+        tag: 6.0.2
+      pupmod-simp-pki:
+        ref: 67b45207d803bc2150ee1018be78560e5ece3c2e
+        tag: 6.0.0
+      pupmod-simp-polkit:
+        ref: 91b57406f1053603bdb7c880aad824b7db906207
+        tag: 6.0.0
+      pupmod-simp-postfix:
+        ref: 6095591ca482fe57cf3525137a996290e7d03052
+        tag: 5.0.1
+      pupmod-simp-pupmod:
+        ref: bc9a0313d1b67d5f6cf3c69677f733d9e717c0d2
+        tag: 7.3.0
+      puppetlabs-puppetdb:
+        ref: 3718c588cf4e40c450dfaae16afc1aac6ad6cb88
+        tag: simp6.0.0-5.1.2
+      pupmod-simp-resolv:
+        ref: 0b2c35cae893e2c83e3162d1fde8878d3f29cdc4
+        tag: 0.0.1
+      pupmod-simp-rsyslog:
+        ref: 14f0ef46df315121c0e136281ac124c57aaf7b91
+        tag: 7.0.2
+      pupmod-simp-selinux:
+        ref: 75393fc9d159d3e4fb08a1324220a45bda6212c6
+        tag: 2.0.2
+      pupmod-simp-simp:
+        ref: c0906fbf43f24cc9286429e8ee81035be7a36084
+        tag: 4.0.0
+      pupmod-simp-simpcat:
+        ref: 50deb1cecc783b28aed39e348da45cd212c37706
+        tag: 6.0.0
+      pupmod-simp-apache:
+        ref: beebf920ffd077e930d7705a7d470d1b22ff3304
+        tag: 1.11.0
+      pupmod-simp-simp_elasticsearch:
+        ref: 5d09a3ace93c3daa97e02ab0863ccf554150fd02
+        tag: 4.1.0-post1
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: d78a6188f5ad6cdf8e0a4e8083b833d2432cdddb
+        tag: 4.0.0
+      pupmod-simp-simp_options:
+        ref: 26e70080b153c37aacbf725b4603f5f0c5698bf6
+        tag: 1.0.1
+      pupmod-simp-simp_nfs:
+        ref: 4842bd85edd6d94a0211b5cf02299ccaf552baf9
+        tag: 0.0.2
+      pupmod-simp-simp_rsyslog:
+        ref: d72f2b1596b4f1f7c52a27c10d8d1fb59e1508d8
+        tag: 0.0.3
+      pupmod-simp-simplib:
+        ref: a5c2758c2d08a23c1a824d132ac4bc1ee5a27651
+        tag: 3.3.1
+      pupmod-simp-site:
+        ref: 61327ae260572365cab6f778cd78f7769aa0d16e
+        tag: 2.0.3
+      pupmod-simp-ssh:
+        ref: 2ff26a6690be2fdbd9e68210bcaf5f4cdc9088bc
+        tag: 6.1.0
+      pupmod-simp-sssd:
+        ref: b4b581657b5564fcece59014d96b04631b97d29a
+        tag: 6.0.1
+      pupmod-simp-stunnel:
+        ref: 5ae55eb3c41e038ecde0a7166b85a5e19018f344
+        tag: 6.0.1
+      pupmod-simp-sudo:
+        ref: c94828d4840951c147c47e1136adb4ebaa92f555
+        tag: 5.0.1
+      pupmod-simp-sudosh:
+        ref: baa03f1e58e5bdc5bb5884bd639c4450ae3b8f61
+        tag: 6.0.0
+      pupmod-simp-svckill:
+        ref: fadd9e6c6a4a163fc77aa27cc7be7b9c7dd0a4a7
+        tag: 3.2.0
+      pupmod-simp-swap:
+        ref: 50cf9df5b2683584664cc88d74ec204494904142
+        tag: 0.1.0
+      pupmod-simp-tcpwrappers:
+        ref: 9c7c58cc0ea9ea2ff51d11899b96f5a56ff306ee
+        tag: 6.0.0
+      pupmod-simp-tftpboot:
+        ref: 878c4ce0cef021c80b6b876df6242cc99a1bbb74
+        tag: 6.0.0
+      pupmod-simp-tpm:
+        ref: 2f59a5bb950f9d6be8b06b54beb180563378e742
+        tag: 1.0.0
+      pupmod-simp-tuned:
+        ref: 7d39b937c6669aee06fb8e8d063ffcc5ad02ab48
+        tag: 0.0.1
+      pupmod-simp-upstart:
+        ref: 84ee9bb62f8cc976e5ec16bd2efc29c1f11ecf9c
+        tag: 6.0.0
+      pupmod-simp-vnc:
+        ref: 628b82476a97a091e673f72cadb89790bda77f30
+        tag: 6.0.1
+      pupmod-simp-vsftpd:
+        ref: 2833f39104be521143990f823824d69b58175b12
+        tag: 7.0.0
+      pupmod-simp-xinetd:
+        ref: 0faddf33856d6c473e4af895c22d4a90c3411aa7
+        tag: 4.0.1
+      pupmod-simp-useradd:
+        ref: 31ce72beec33febc55a187059c34ffa8ac87e71f
+        tag: 0.1.0
+      puppet-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        tag: simp6.0.0-2.0.0
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/6.2.0-0.yaml
+++ b/v1/releases/6.2.0-0.yaml
@@ -1,468 +1,473 @@
 ---
 releases:
   6.2.0-0:
-    simp-core:
-      ref: 7c0e2812dfe955de339c48aeed70b8c333dbf215
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: 28e879d425ec54035fe1a74b3c4eadfbc7ee7615
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: b3534c8eb35d9dd527e6459a54277feb8d614f80
-      branch: master
-      tag: 6.0.6
-    simp-rsync_skeleton:
-      ref: aaf439407429acd8a1f07d9f7505eb232a8bcd62
-      branch: master
-      tag: 6.2.1
-      compiled: true
-    simp-adapter:
-      ref: c1cb4e2cc03bc9bed0f828d4bf30fcb46b540216
-      branch: master
-      tag: 0.0.6
-      compiled: true
-    simp-environment:
-      ref: 86ffad13755cd6e5e97a4de683a1a1a967d50854
-      branch: master
-      tag: 6.2.10
-      compiled: true
-    simp-gpgkeys:
-      ref: b5e27809d94f1db6f716cce5621e7b997b84be77
-      branch: master
-      tag: 3.0.3
-    simp-utils:
-      ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
-      branch: master
-      tag: 6.1.1
-    rubygem-simp-cli:
-      ref: caabbaacd96c9cd59d5a4b821b8dcf26c57df502
-      branch: master
-      tag: 4.2.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-      compiled: true
-    camptocamp-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    elastic-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    elastic-logstash:
-      tag: 5.3.0
-      branch: master
-      ref: 212439a83fa900f0212095a84a420e49d9788fc7
-    herculesteam-augeasproviders_apache:
-      ref: 4e9ff96f1fc919fb96e59d03a3180bcb70c9cf65
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    herculesteam-augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    herculesteam-augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    herculesteam-augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    herculesteam-augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    herculesteam-augeasproviders_shellvar:
-      ref: 4607570dfc526ce357f1e3f3ad98e232e88a06e8
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    herculesteam-augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    onyxpoint-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: 3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: 4.1.1
-    puppetlabs-docker:
-      ref: 11dc4a66a86978f22ce057e5027fe20243d26916
-      tag: 1.1.0
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: 2.2.0
-    puppetlabs-java:
-      ref: 10503819d25aefd2fc457de82c76835982903b03
-      branch: master
-      tag: 2.4.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: ba5fe245b103a8c717ee93684cf466663a794363
-      branch: master
-      tag: 1.9.0
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: 5.3.0
-    puppetlabs-postgresql:
-      ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
-      branch: master
-      tag: 5.4.0
-    puppetlabs-stdlib:
-      tag: 4.25.1
-      branch: master
-      ref: 45454b8de4ff8f860f6f78438107133e510336ed
-    richardc-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    pupmod-simp-acpid:
-      ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
-      branch: master
-      tag: 1.0.2
-    pupmod-simp-aide:
-      ref: 64e72ac447d5b00a445750a3312183f91aede28a
-      branch: master
-      tag: 6.1.4
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
-      branch: master
-      tag: 7.1.3
-    pupmod-simp-autofs:
-      ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-chkrootkit:
-      ref: 11221ddfb826123167ca898a53269634c264ca15
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-clamav:
-      ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-compliance_markup:
-      ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-cron:
-      ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-dconf:
-      ref: 66ba6f224f14211600897faca9dd784fad1b871f
-      branch: master
-      tag: 0.0.1
-    pupmod-simp-dhcp:
-      ref: b77511e47f6b1da325cc667ba26b52700a6b17af
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-dirtycow:
-      ref: 16a8228b4bebec6d12340124f89529c4e7700b22
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-fips:
-      ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
-      branch: master
-      tag: 0.1.4
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: ab95fadc39f917a75c937f25007c9e9c4b172816
-      branch: master
-      tag: 7.0.1
-    simp-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: 643d7a0d2321591c4eee129a532b9721b1fd1567
-      branch: master
-      tag: 0.3.0
-    pupmod-simp-iptables:
-      ref: f889bc858c43efee8819bf9b616fb25c0505a0d5
-      branch: master
-      tag: 6.1.5
-    pupmod-simp-issue:
-      ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
-      branch: master
-      tag: 0.0.2
-    cristifalcas-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: 943064852e1dc4aadc0829cb0ade968363802fb8
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-mozilla:
-      ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-named:
-      ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 7c0625cb57134254109db2cc330a0106758fb763
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: ae32f1a0075448100e58da2100ae09e9681a23cd
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-oddjob:
-      ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
-      branch: master
-      tag: 2.0.1
-    pupmod-simp-simp_openldap:
-      ref: 8a276bbd5df0e7ca4cf1c0b766a8f3d63f54709d
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: 679e241ffbc09bd9f8dfd9ec89f9f554ea1bc5e7
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: f1342d2ac62d98bbc23a9d58cf2a03fca025ec5b
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 139e4db9e8381ee30e5520dd7f2dabb35af9e451
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-postfix:
-      ref: c8f46807ba1fa5da3564e8e75736e00b0972f457
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: f70b12e798122d3c315e26bf7db71c183e636ae6
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 74d6139036748257e451db316189cfe117360eb4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: 013dd5a7528f08569886eedbd6e575b906880ea7
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: 7957c04e1998db51ed495bbd0faeb7d112fc7318
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: d287b90cb654de7e2857697391d556de1f9d1023
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_apache:
-      ref: a0b61eb6ddc22ff810f7f47576f1677712752160
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-simp_docker:
-      ref: e0fa56ccfead3d30425627e75233a0862ec79310
-      tag: 0.1.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 4ff080594befe6190897ff97dcf3e8f717a9e7ab
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_grafana:
-      ref: f2be07fbe265161accc97d9a35bd88436f6ec764
-      branch: master
-      tag: 1.0.5
-    pupmod-simp-simp_ipa:
-      ref: 20d6c8510d0b8403f503eebc7c8f9725b401a00b
-      branch: master
-      tag: 0.0.1
-    pupmod-simp-simp_logstash:
-      ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
-      branch: master
-      tag: 5.0.1
-    pupmod-simp-simp_options:
-      ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
-      branch: master
-      tag: 1.2.0
-    pupmod-simp-simp_nfs:
-      ref: c7c8b349ceec97431788b48a4267969c72fd8cc2
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: f7c4a46b8a19e6af279f42acb5f65af569ac4dd3
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
-      branch: master
-      tag: 2.0.4
-    pupmod-simp-ssh:
-      ref: 22a817680126e3ff9cd2497fbe6d3ebf92722730
-      branch: master
-      tag: 6.4.3
-    pupmod-simp-sssd:
-      ref: 3c2e55a187ac8f93e8df45bacdf1ec973b20fa95
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-stunnel:
-      ref: 911a698e1e53d73dda29002b83f3776ca1e99d1a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 22d93a94ec85c6b107382b8eb9a4d808a556fb9c
-      branch: master
-      tag: 5.0.6
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: 32bf9b7b24b0bccd3bf6e3d77d94f959142b4ae3
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: e24affac278bd91ebceb3d18031408a8913dd83f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-tftpboot:
-      ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tpm:
-      ref: ad2a812b278e9ca17d610590c2d842d735dd92de
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
-      branch: master
-      tag: 0.0.2
-    pupmod-simp-upstart:
-      ref: 6b4635a95178c2eba7bb7ba93ce468cdd0976bb6
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-vnc:
-      ref: 25f0fe22bd9c87c4566f3ed90470ac80f5867b97
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vsftpd:
-      ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-xinetd:
-      ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
-      branch: master
-      tag: 4.0.2
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    trlinkin-nsswitch:
-      ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
-      branch: master
-      tag: simp6.0.0-2.0.0
-    simp-systemd:
-      tag: simp-1.1.1
-      ref: cf207e6b4ffb950cce8cd2ba9cb2dbe5f110b048
-    puppetlabs-hocon:
-      tag: 1.0.0
-      ref: b2d8c1bbc7c2ac50505b1b77d623ff29d6d5180d
-    puppetlabs-mount_providers:
-      tag: 1.0.0
-      ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
-    puppetlabs-translate:
-      tag: 1.0.0
-      ref: 9455a26726954ad180d910a1269d52eccbfb941c
-    razorsedge-snmp:
-      tag: 3.9.0
-      ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
-    simp-simp_gitlab:
-      tag: 0.3.3
-      ref: f4c7e619f20ffdff8cd3b123ef66cda8ef3291bb
-    simp-simp_snmpd:
-      tag: 0.0.3
-      ref: 86b72e48bccadabdb1299d69bf963a4695053754
-    simp-timezone:
-      tag: 4.0.0
-      ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
-    voxpupuli-yum:
-      tag: v2.2.1
-      ref: fc40cab9abf09eb864aab32fe420149a7353c524
-    vshn-gitlab:
-      tag: v1.13.3
-      ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
-      revision: 2016.1
+    components:
+      simp-core:
+        ref: 7c0e2812dfe955de339c48aeed70b8c333dbf215
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: 28e879d425ec54035fe1a74b3c4eadfbc7ee7615
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: b3534c8eb35d9dd527e6459a54277feb8d614f80
+        branch: master
+        tag: 6.0.6
+      simp-rsync_skeleton:
+        ref: aaf439407429acd8a1f07d9f7505eb232a8bcd62
+        branch: master
+        tag: 6.2.1
+        compiled: true
+      simp-adapter:
+        ref: c1cb4e2cc03bc9bed0f828d4bf30fcb46b540216
+        branch: master
+        tag: 0.0.6
+        compiled: true
+      simp-environment:
+        ref: 86ffad13755cd6e5e97a4de683a1a1a967d50854
+        branch: master
+        tag: 6.2.10
+        compiled: true
+      simp-gpgkeys:
+        ref: b5e27809d94f1db6f716cce5621e7b997b84be77
+        branch: master
+        tag: 3.0.3
+      simp-utils:
+        ref: f43af3ae3a141fab1aa0a8a0fb3e9c914abbebd1
+        branch: master
+        tag: 6.1.1
+      rubygem-simp-cli:
+        ref: caabbaacd96c9cd59d5a4b821b8dcf26c57df502
+        branch: master
+        tag: 4.2.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+        compiled: true
+      camptocamp-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      elastic-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      elastic-logstash:
+        tag: 5.3.0
+        branch: master
+        ref: 212439a83fa900f0212095a84a420e49d9788fc7
+      herculesteam-augeasproviders_apache:
+        ref: 4e9ff96f1fc919fb96e59d03a3180bcb70c9cf65
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      herculesteam-augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      herculesteam-augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      herculesteam-augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      herculesteam-augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      herculesteam-augeasproviders_shellvar:
+        ref: 4607570dfc526ce357f1e3f3ad98e232e88a06e8
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      herculesteam-augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      onyxpoint-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: 3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: 4.1.1
+      puppetlabs-docker:
+        ref: 11dc4a66a86978f22ce057e5027fe20243d26916
+        tag: 1.1.0
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: 2.2.0
+      puppetlabs-java:
+        ref: 10503819d25aefd2fc457de82c76835982903b03
+        branch: master
+        tag: 2.4.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: ba5fe245b103a8c717ee93684cf466663a794363
+        branch: master
+        tag: 1.9.0
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: 5.3.0
+      puppetlabs-postgresql:
+        ref: 4c91554ca98af7ff5315c2a1892e7074b272f6a7
+        branch: master
+        tag: 5.4.0
+      puppetlabs-stdlib:
+        tag: 4.25.1
+        branch: master
+        ref: 45454b8de4ff8f860f6f78438107133e510336ed
+      richardc-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      pupmod-simp-acpid:
+        ref: 403c1cee95ee22a27a2e8cba26067b26f99e40d7
+        branch: master
+        tag: 1.0.2
+      pupmod-simp-aide:
+        ref: 64e72ac447d5b00a445750a3312183f91aede28a
+        branch: master
+        tag: 6.1.4
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8b7ed6ef3ad9f683c9cd170c7d962c8b1e41f4d0
+        branch: master
+        tag: 7.1.3
+      pupmod-simp-autofs:
+        ref: 02aae8fc49e49d381ed42ea0bb60a5b24d87442e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-chkrootkit:
+        ref: 11221ddfb826123167ca898a53269634c264ca15
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-clamav:
+        ref: dbd2426cd0e1cc25e32bbd307bcefc19954f595b
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-compliance_markup:
+        ref: ea40ab4e3fdc4c535c66cdd055955ddf5ee4b1f9
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-cron:
+        ref: c63db83da298a60d8ae3cd6ce62a92211e398b21
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-dconf:
+        ref: 66ba6f224f14211600897faca9dd784fad1b871f
+        branch: master
+        tag: 0.0.1
+      pupmod-simp-dhcp:
+        ref: b77511e47f6b1da325cc667ba26b52700a6b17af
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-dirtycow:
+        ref: 16a8228b4bebec6d12340124f89529c4e7700b22
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-fips:
+        ref: 62eb8b17c9fa6fff0143fe457e16619116cf8713
+        branch: master
+        tag: 0.1.4
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: ab95fadc39f917a75c937f25007c9e9c4b172816
+        branch: master
+        tag: 7.0.1
+      simp-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: 643d7a0d2321591c4eee129a532b9721b1fd1567
+        branch: master
+        tag: 0.3.0
+      pupmod-simp-iptables:
+        ref: f889bc858c43efee8819bf9b616fb25c0505a0d5
+        branch: master
+        tag: 6.1.5
+      pupmod-simp-issue:
+        ref: 1ae3867a50d8baad9bbba8ed09e598dde0e716ee
+        branch: master
+        tag: 0.0.2
+      cristifalcas-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: 943064852e1dc4aadc0829cb0ade968363802fb8
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-mozilla:
+        ref: 8e9b013f59559a598479bfe6b3cf81ca967c718a
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-named:
+        ref: e1988ad8e344457c2b8ab673d2bf86e00ff3c384
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 7c0625cb57134254109db2cc330a0106758fb763
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: ae32f1a0075448100e58da2100ae09e9681a23cd
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-oddjob:
+        ref: bdd6a0d37734ec58a035b5b3ae117de2cab6ff45
+        branch: master
+        tag: 2.0.1
+      pupmod-simp-simp_openldap:
+        ref: 8a276bbd5df0e7ca4cf1c0b766a8f3d63f54709d
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: 679e241ffbc09bd9f8dfd9ec89f9f554ea1bc5e7
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: f1342d2ac62d98bbc23a9d58cf2a03fca025ec5b
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 139e4db9e8381ee30e5520dd7f2dabb35af9e451
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 9fc7cf72dd8f81d539969003795f565e3c2a822b
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-postfix:
+        ref: c8f46807ba1fa5da3564e8e75736e00b0972f457
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: f70b12e798122d3c315e26bf7db71c183e636ae6
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: c076aabb2e9df16e7955b44ea6d0b94682a80c62
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 74d6139036748257e451db316189cfe117360eb4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: 013dd5a7528f08569886eedbd6e575b906880ea7
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: 7957c04e1998db51ed495bbd0faeb7d112fc7318
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: d287b90cb654de7e2857697391d556de1f9d1023
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_apache:
+        ref: a0b61eb6ddc22ff810f7f47576f1677712752160
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-simp_docker:
+        ref: e0fa56ccfead3d30425627e75233a0862ec79310
+        tag: 0.1.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 4ff080594befe6190897ff97dcf3e8f717a9e7ab
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_grafana:
+        ref: f2be07fbe265161accc97d9a35bd88436f6ec764
+        branch: master
+        tag: 1.0.5
+      pupmod-simp-simp_ipa:
+        ref: 20d6c8510d0b8403f503eebc7c8f9725b401a00b
+        branch: master
+        tag: 0.0.1
+      pupmod-simp-simp_logstash:
+        ref: 315eb9cb2cc37214c2fbdf20beeaca67e064fbc7
+        branch: master
+        tag: 5.0.1
+      pupmod-simp-simp_options:
+        ref: 0c95af2d0f71898ddd243e1ebd5695a5b3695eb0
+        branch: master
+        tag: 1.2.0
+      pupmod-simp-simp_nfs:
+        ref: c7c8b349ceec97431788b48a4267969c72fd8cc2
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: f7c4a46b8a19e6af279f42acb5f65af569ac4dd3
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 0ba070f208ce5965ff0e701d286df55ab6806fd6
+        branch: master
+        tag: 2.0.4
+      pupmod-simp-ssh:
+        ref: 22a817680126e3ff9cd2497fbe6d3ebf92722730
+        branch: master
+        tag: 6.4.3
+      pupmod-simp-sssd:
+        ref: 3c2e55a187ac8f93e8df45bacdf1ec973b20fa95
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-stunnel:
+        ref: 911a698e1e53d73dda29002b83f3776ca1e99d1a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 22d93a94ec85c6b107382b8eb9a4d808a556fb9c
+        branch: master
+        tag: 5.0.6
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: 32bf9b7b24b0bccd3bf6e3d77d94f959142b4ae3
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: e24affac278bd91ebceb3d18031408a8913dd83f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-tftpboot:
+        ref: 60f551fdb044bb73c5d020c691945e1129c3ea66
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tpm:
+        ref: ad2a812b278e9ca17d610590c2d842d735dd92de
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 4a30770c89b70dd0df73d677ffc401e6eece6434
+        branch: master
+        tag: 0.0.2
+      pupmod-simp-upstart:
+        ref: 6b4635a95178c2eba7bb7ba93ce468cdd0976bb6
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-vnc:
+        ref: 25f0fe22bd9c87c4566f3ed90470ac80f5867b97
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vsftpd:
+        ref: 4ec3fe355ee60025842b34981f70b1bf5c315fb4
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-xinetd:
+        ref: bdd83df1e5cb736481e1c74d3e22d79556bdb4b2
+        branch: master
+        tag: 4.0.2
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      trlinkin-nsswitch:
+        ref: 6a2fee0947932dbde3c96ff75f5e461931366c78
+        branch: master
+        tag: simp6.0.0-2.0.0
+      simp-systemd:
+        tag: simp-1.1.1
+        ref: cf207e6b4ffb950cce8cd2ba9cb2dbe5f110b048
+      puppetlabs-hocon:
+        tag: 1.0.0
+        ref: b2d8c1bbc7c2ac50505b1b77d623ff29d6d5180d
+      puppetlabs-mount_providers:
+        tag: 1.0.0
+        ref: 127bc7d8e7af6e94d3f3513334094c7560372efa
+      puppetlabs-translate:
+        tag: 1.0.0
+        ref: 9455a26726954ad180d910a1269d52eccbfb941c
+      razorsedge-snmp:
+        tag: 3.9.0
+        ref: 72e43bfab001b1a6d94bd5d66006e1eeb8471536
+      simp-simp_gitlab:
+        tag: 0.3.3
+        ref: f4c7e619f20ffdff8cd3b123ef66cda8ef3291bb
+      simp-simp_snmpd:
+        tag: 0.0.3
+        ref: 86b72e48bccadabdb1299d69bf963a4695053754
+      simp-timezone:
+        tag: 4.0.0
+        ref: 7308a0235f6a6cab67e7c5076082a1940c0fd4db
+      voxpupuli-yum:
+        tag: v2.2.1
+        ref: fc40cab9abf09eb864aab32fe420149a7353c524
+      vshn-gitlab:
+        tag: v1.13.3
+        ref: 5de09ad4bb8398a336b0651ba1f4f5e2406300cf
+        revision: 2016.1
+    platforms:
+      CentOS-7.4-x86_64:
+      CentOS-6.9-x86_64:
+      RedHat-7.4-x86_64:

--- a/v1/releases/unstable.yaml
+++ b/v1/releases/unstable.yaml
@@ -1,477 +1,482 @@
 ---
 releases:
   unstable:
-    simp-core:
-      ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
-      branch: master
-      tag: 6.2.0-0
-    simp-doc:
-      ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
-      branch: master
-      tag: 6.2.0-0
-    pupmod-simp-rsync:
-      ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
-      branch: master
-      tag: 6.0.6
-    simp-rsync:
-      ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
-      branch: master
-      tag: 6.2.0
-    simp-adapter:
-      ref: bd992f09b127b59ac8a212856eaee56304035bfa
-      branch: master
-      tag: 0.1.0
-    simp-environment:
-      ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
-      branch: master
-      tag: 6.3.0
-    simp-gpgkeys:
-      ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
-      branch: master
-      tag: 3.0.4
-    simp-utils:
-      ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
-      branch: master
-      tag: 6.1.2
-    rubygem-simp-cli:
-      ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
-      branch: master
-      tag: 4.3.0
-    puppet-grafana:
-      ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
-      branch: master
-      tag: v4.1.1
-    puppet-kmod:
-      tag: 2.2.0
-      branch: master
-      ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
-    puppet-elasticsearch:
-      tag: 5.5.0
-      branch: master
-      ref: 7d297e0002f1519e488620b7580963c80fe89f18
-    puppet-logstash:
-      tag: 6.0.2
-      branch: master
-      ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
-    puppet-file_concat:
-      ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
-      branch: master
-      tag: simp6.0.0-1.0.1
-    augeasproviders:
-      ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
-      branch: master
-      tag: v2.1.3
-    augeasproviders_apache:
-      ref: d2d51f011c845c888151a95d00a4972ec1054a6b
-      branch: master
-      tag: 3.0.0
-    augeasproviders_base:
-      ref: de6152df502f2642003c439195acc438c6da69b3
-      branch: master
-      tag: simp6.0.0-2.0.1
-    augeasproviders_core:
-      ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
-      branch: master
-      tag: 2.1.4
-    augeasproviders_grub:
-      ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
-      branch: master
-      tag: 3.0.1
-    augeasproviders_mounttab:
-      ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
-      branch: master
-      tag: 2.0.3
-    augeasproviders_nagios:
-      ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
-      branch: master
-      tag: 2.0.2
-    augeasproviders_pam:
-      ref: e20796872f094c56a201519bab7716f099c78819
-      branch: master
-      tag: 2.1.1
-    augeasproviders_postgresql:
-      ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
-      branch: master
-      tag: 3.0.0
-    augeasproviders_puppet:
-      ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
-      branch: master
-      tag: 2.1.1
-    augeasproviders_shellvar:
-      ref: 67c592af6fdfbee92e61733b5f146c851b93232c
-      branch: master
-      tag: 2.2.4
-    augeasproviders_ssh:
-      ref: 44273c14afb678135bf2812550ac982a54c1eab4
-      branch: master
-      tag: 3.0.0
-    augeasproviders_sysctl:
-      ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
-      branch: master
-      tag: 2.2.0
-    puppet-gpasswd:
-      ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
-      branch: master
-      tag: 1.0.5
-    puppetlabs-apache:
-      ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
-      branch: master
-      tag: simp6.0.0-3.0.0
-    puppetlabs-concat:
-      ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
-      branch: master
-      tag: simp6.0.0-4.1.1
-    puppetlabs-inifile:
-      ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
-      branch: master
-      tag: simp6.0.0-2.2.0
-    puppetlabs-java:
-      ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
-      branch: master
-      tag: 3.2.0
-    puppetlabs-java_ks:
-      ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
-      branch: master
-      tag: 2.1.0
-    puppetlabs-puppet_authorization:
-      ref: 963830013512398d2d0212950fb4572edb598539
-      branch: master
-      tag: 0.4.0
-    puppetlabs-motd:
-      ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
-      branch: master
-      tag: 2.1.1
-    puppetlabs-mysql:
-      ref: c25b4396db0cf657c07194921519deda3c66f68e
-      branch: master
-      tag: simp6.0.0-5.3.0
-    puppetlabs-postgresql:
-      ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
-      branch: master
-      tag: 5.10.0
-    puppetlabs-stdlib:
-      tag: 5.1.0
-      branch: master
-      ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
-    puppet-datacat:
-      ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
-      branch: master
-      tag: simp6.0.0-0.6.2
-    puppet-timezone:
-      ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
-      branch: master
-      tag: v3.5.0
-    pupmod-simp-acpid:
-      ref: 5cb19160c858e58fe352200799ee235349f67b59
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-activemq:
-      ref: 6209548987267a9f6518a81c06e5028e3baa72e7
-      branch: master
-      tag: 4.0.1
-    pupmod-simp-aide:
-      ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-at:
-      ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
-      branch: master
-      tag: 0.0.4
-    pupmod-simp-auditd:
-      ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
-      branch: master
-      tag: 8.1.1
-    pupmod-simp-autofs:
-      ref: b1577b215869bd30fd216ab6922266c8f78dca5e
-      branch: master
-      tag: 6.1.2
-    pupmod-simp-chkrootkit:
-      ref: e7e1273e5795864955875e2d7dceb04441a8a048
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-clamav:
-      ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-compliance_markup:
-      ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
-      branch: master
-      tag: 2.3.2
-    pupmod-simp-cron:
-      ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-dhcp:
-      ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-dirtycow:
-      ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
-      branch: master
-      tag: 1.0.4
-    pupmod-simp-fips:
-      ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-freeradius:
-      ref: b1c04e009efad2ff535963a239d96eb6232676f0
-      branch: master
-      tag: 7.0.1
-    pupmod-simp-gdm:
-      ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-gnome:
-      ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
-      branch: master
-      tag: 8.0.0
-    puppet-haveged:
-      ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
-      branch: master
-      tag: 0.4.5
-    pupmod-simp-incron:
-      ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
-      branch: master
-      tag: 0.3.1
-    pupmod-simp-iptables:
-      ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
-      branch: master
-      tag: 6.1.6
-    pupmod-simp-issue:
-      ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
-      branch: master
-      tag: 0.0.3
-    pupmod-simp-jenkins:
-      ref: add24f99fb3c5f7537489f0766b85f6273cf808e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-journald:
-      ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
-      branch: master
-      tag: 0.6.0
-    pupmod-simp-krb5:
-      ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
-      branch: master
-      tag: 7.0.3
-    pupmod-simp-libreswan:
-      ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
-      branch: master
-      tag: 3.0.2
-    pupmod-simp-libvirt:
-      ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-logrotate:
-      ref: c2f9835bd39fe880696869a804a8a86ffb14e550
-      branch: master
-      tag: 6.3.0
-    pupmod-simp-mcafee:
-      ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-mcollective:
-      ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
-      branch: master
-      tag: 2.3.3
-    pupmod-simp-mozilla:
-      ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-named:
-      ref: 851fdeb82573b593ff935a9bd208b77395b5af87
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-network:
-      ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-nfs:
-      ref: 88889f936f764a80d270f7e8c70458ee503bd51e
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-ntpd:
-      ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-oddjob:
-      ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
-      branch: master
-      tag: 2.1.0
-    pupmod-simp-simp_openldap:
-      ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-openscap:
-      ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-pam:
-      ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
-      branch: master
-      tag: 6.2.1
-    pupmod-simp-pki:
-      ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-polkit:
-      ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
-      branch: master
-      tag: 6.1.1
-    pupmod-simp-postfix:
-      ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
-      branch: master
-      tag: 5.1.0
-    pupmod-simp-pupmod:
-      ref: 34652dddafb89edbae24eed18580c434cc5d46a5
-      branch: master
-      tag: 7.6.1
-    puppetlabs-puppetdb:
-      ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
-      branch: master
-      tag: 7.1.0
-    pupmod-simp-resolv:
-      ref: 8dffcc02d51b80574596a54bb7496478effa05b0
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-rsyslog:
-      ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-selinux:
-      ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
-      branch: master
-      tag: 2.2.0
-    pupmod-simp-simp:
-      ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
-      branch: master
-      tag: 4.5.0
-    pupmod-simp-simpcat:
-      ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
-      branch: master
-      tag: 6.0.2
-    pupmod-simp-apache:
-      ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-simp_elasticsearch:
-      ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
-      branch: master
-      tag: 5.0.4
-    pupmod-simp-simp_grafana:
-      ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
-      branch: master
-      tag: 1.0.3
-    pupmod-simp-simp_logstash:
-      ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
-      branch: master
-      tag: 5.0.2
-    pupmod-simp-simp_options:
-      ref: 48ff34d16499364da5b47c526949473c7e0682ce
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-simp_nfs:
-      ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
-      branch: master
-      tag: 0.0.5
-    pupmod-simp-simp_rsyslog:
-      ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
-      branch: master
-      tag: 0.2.0
-    pupmod-simp-simplib:
-      ref: bad2f755426586868ab0720ad11eb2a42c0c7447
-      branch: master
-      tag: 3.11.0
-    pupmod-simp-site:
-      ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
-      branch: master
-      tag: 2.0.5
-    pupmod-simp-ssh:
-      ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
-      branch: master
-      tag: 6.4.4
-    pupmod-simp-sssd:
-      ref: 8fb7d2685984708347fc3d707332acfa9186d398
-      branch: master
-      tag: 6.1.3
-    pupmod-simp-stunnel:
-      ref: b32720c639952b9d8f3a96e2724648d6609a672a
-      branch: master
-      tag: 6.3.2
-    pupmod-simp-sudo:
-      ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
-      branch: master
-      tag: 5.1.1
-    pupmod-simp-sudosh:
-      ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
-      branch: master
-      tag: 6.0.1
-    pupmod-simp-svckill:
-      ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
-      branch: master
-      tag: 3.2.6
-    pupmod-simp-swap:
-      ref: d027e3607ac337918a2174e170a72ad57cd49da0
-      branch: master
-      tag: 0.1.1
-    pupmod-simp-tcpwrappers:
-      ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
-      branch: master
-      tag: 6.1.0
-    pupmod-simp-tftpboot:
-      ref: a401004a373decd1e6bdc92fae6620ba6160585d
-      branch: master
-      tag: 6.2.0
-    pupmod-simp-tpm:
-      ref: f50654075b249f5a427dfe28bd7f665f9b36944a
-      branch: master
-      tag: 1.2.1
-    pupmod-simp-tuned:
-      ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
-      branch: master
-      tag: 0.1.0
-    pupmod-simp-upstart:
-      ref: 7da363b00ffbb52096c958a987cb3064465b987f
-      branch: master
-      tag: 6.0.3
-    pupmod-simp-vnc:
-      ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
-      branch: master
-      tag: 7.0.0
-    pupmod-simp-vsftpd:
-      ref: 7fe4dd4983665361dae6503b8941e48e107041b7
-      branch: master
-      tag: 7.2.0
-    pupmod-simp-xinetd:
-      ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
-      branch: master
-      tag: 4.1.0
-    pupmod-simp-useradd:
-      ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
-      branch: master
-      tag: 0.2.1
-    puppet-nsswitch:
-      ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
-      branch: master
-      tag: 2.0.0
-    pupmod-simp-libkv:
-      tag: 0.6.1f
-      ref: de631cc5c485fd872c719955b780861e76fea6d5
-      branch: develop
-    pupmod-simp-simp_consul:
-      tag: 0.1.0
-      ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
-      branch: develop
-    solarkennedy-consul:
-      ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
-      tag: v3.3.1
-    puppet-archive:
-      ref: 62f42713403dd9102bb1ac687924ea00dab50741
-    rubygem-simp-metadata:
-      ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
-      tag: 0.5.2
-    rubygem-simp-rake-helpers:
-      ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
-      tag: 5.6.3
-    pkg-r10k:
-      tag: 2.6.2-1
-      ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    components:
+      simp-core:
+        ref: 1ca5327c1d8da5256d1065478ed1520e2a01bf7a
+        branch: master
+        tag: 6.2.0-0
+      simp-doc:
+        ref: e6f8d7f763177b163ed14ffcb6e76cdf7561d04a
+        branch: master
+        tag: 6.2.0-0
+      pupmod-simp-rsync:
+        ref: e1247b9b5b0dd8b0abda55c743648d38442e66b0
+        branch: master
+        tag: 6.0.6
+      simp-rsync:
+        ref: 472f8da85d4b6b3d8579e60c168c84c578f818d5
+        branch: master
+        tag: 6.2.0
+      simp-adapter:
+        ref: bd992f09b127b59ac8a212856eaee56304035bfa
+        branch: master
+        tag: 0.1.0
+      simp-environment:
+        ref: f68243f6c6736e7fe0eccbc3cb19ee333d7773fb
+        branch: master
+        tag: 6.3.0
+      simp-gpgkeys:
+        ref: bbd08c58b54a6bba740a0bb42685f853c78e028a
+        branch: master
+        tag: 3.0.4
+      simp-utils:
+        ref: 258fe960f57757416fa6ab7e0679f9fcb2871ec6
+        branch: master
+        tag: 6.1.2
+      rubygem-simp-cli:
+        ref: 32040e19bdb50f5a90cfd39b91450d312a5874bc
+        branch: master
+        tag: 4.3.0
+      puppet-grafana:
+        ref: 9ccb9bbe66cb44118ebbc9f91ab2a5c99440dbe3
+        branch: master
+        tag: v4.1.1
+      puppet-kmod:
+        tag: 2.2.0
+        branch: master
+        ref: 7c17b7dbc4fbf1f63f6bae197acdbab78f7f12fd
+      puppet-elasticsearch:
+        tag: 5.5.0
+        branch: master
+        ref: 7d297e0002f1519e488620b7580963c80fe89f18
+      puppet-logstash:
+        tag: 6.0.2
+        branch: master
+        ref: '08cc70dbcfd19f669cc2cf3cfecac817105569f6'
+      puppet-file_concat:
+        ref: 813132b5d776204e1da169a93e4bc6a1e253f75c
+        branch: master
+        tag: simp6.0.0-1.0.1
+      augeasproviders:
+        ref: bbfc6ff9fa9acfd39e1ae9aff6341dc07e86a8d4
+        branch: master
+        tag: v2.1.3
+      augeasproviders_apache:
+        ref: d2d51f011c845c888151a95d00a4972ec1054a6b
+        branch: master
+        tag: 3.0.0
+      augeasproviders_base:
+        ref: de6152df502f2642003c439195acc438c6da69b3
+        branch: master
+        tag: simp6.0.0-2.0.1
+      augeasproviders_core:
+        ref: 604680cb5fe7e32fd1ad1051fc34ef100a4d6923
+        branch: master
+        tag: 2.1.4
+      augeasproviders_grub:
+        ref: aa550a1b1df303eb2a07b80634f5e83b5ad718b8
+        branch: master
+        tag: 3.0.1
+      augeasproviders_mounttab:
+        ref: 169d2cd9730059fb4dab983b864ba1abab73ed14
+        branch: master
+        tag: 2.0.3
+      augeasproviders_nagios:
+        ref: bd572653fb3de18c3ae920b9608989d5ca14ff9c
+        branch: master
+        tag: 2.0.2
+      augeasproviders_pam:
+        ref: e20796872f094c56a201519bab7716f099c78819
+        branch: master
+        tag: 2.1.1
+      augeasproviders_postgresql:
+        ref: 39d033fd9fa5ce1d67bbac81148c3d63615378a9
+        branch: master
+        tag: 3.0.0
+      augeasproviders_puppet:
+        ref: 5419f7e19c5721f2ed54654e791fd6bbc3be9707
+        branch: master
+        tag: 2.1.1
+      augeasproviders_shellvar:
+        ref: 67c592af6fdfbee92e61733b5f146c851b93232c
+        branch: master
+        tag: 2.2.4
+      augeasproviders_ssh:
+        ref: 44273c14afb678135bf2812550ac982a54c1eab4
+        branch: master
+        tag: 3.0.0
+      augeasproviders_sysctl:
+        ref: 012cd99bb6f1fdf210a2bc1c3f153138643dfb48
+        branch: master
+        tag: 2.2.0
+      puppet-gpasswd:
+        ref: 5859d88cea1f9841dda6cca321c9d106e9f0559a
+        branch: master
+        tag: 1.0.5
+      puppetlabs-apache:
+        ref: 0b270f9bfe0830c95052a5ea1a205af14c01ed79
+        branch: master
+        tag: simp6.0.0-3.0.0
+      puppetlabs-concat:
+        ref: c95dc13ea769d187a1ad3e51f45f4c266baa7825
+        branch: master
+        tag: simp6.0.0-4.1.1
+      puppetlabs-inifile:
+        ref: b8a43a73d6b88236c851bbf87c1891ddc5d70497
+        branch: master
+        tag: simp6.0.0-2.2.0
+      puppetlabs-java:
+        ref: 46a6c7a4235401e554c4e14d4f5f284134921e17
+        branch: master
+        tag: 3.2.0
+      puppetlabs-java_ks:
+        ref: '029a74c9cd1a1c8321f5582e392de26735d07d91'
+        branch: master
+        tag: 2.1.0
+      puppetlabs-puppet_authorization:
+        ref: 963830013512398d2d0212950fb4572edb598539
+        branch: master
+        tag: 0.4.0
+      puppetlabs-motd:
+        ref: 6b5a08905b0f50c6d4cf5cee468ecfb32f589e25
+        branch: master
+        tag: 2.1.1
+      puppetlabs-mysql:
+        ref: c25b4396db0cf657c07194921519deda3c66f68e
+        branch: master
+        tag: simp6.0.0-5.3.0
+      puppetlabs-postgresql:
+        ref: 27c0d53aad86346f6d4117448a1dba2dbb21e8cd
+        branch: master
+        tag: 5.10.0
+      puppetlabs-stdlib:
+        tag: 5.1.0
+        branch: master
+        ref: 69a84c0bb8d095747206a0fbbcf01e9704e9b839
+      puppet-datacat:
+        ref: 93b88b78364ee35f2bf39ca98ad08b78f423c1d2
+        branch: master
+        tag: simp6.0.0-0.6.2
+      puppet-timezone:
+        ref: c9db0461d16959ed195ef2e44f29f88ecffd9c09
+        branch: master
+        tag: v3.5.0
+      pupmod-simp-acpid:
+        ref: 5cb19160c858e58fe352200799ee235349f67b59
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-activemq:
+        ref: 6209548987267a9f6518a81c06e5028e3baa72e7
+        branch: master
+        tag: 4.0.1
+      pupmod-simp-aide:
+        ref: 5c218702ff07b06efadb497ba3dec57ea996f18e
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-at:
+        ref: 64a0eaadaa2bfd0f332fec95d35575b8287141d7
+        branch: master
+        tag: 0.0.4
+      pupmod-simp-auditd:
+        ref: 8a2022bf14d587b24ad09b0efd3a2cedfa96d0c1
+        branch: master
+        tag: 8.1.1
+      pupmod-simp-autofs:
+        ref: b1577b215869bd30fd216ab6922266c8f78dca5e
+        branch: master
+        tag: 6.1.2
+      pupmod-simp-chkrootkit:
+        ref: e7e1273e5795864955875e2d7dceb04441a8a048
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-clamav:
+        ref: 2149bf344b262e062e5a5e095dfa167f9d9e8e7d
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-compliance_markup:
+        ref: d36eb8c2cde0eda8c33148ea473388bde9a77f7f
+        branch: master
+        tag: 2.3.2
+      pupmod-simp-cron:
+        ref: 4e9cc4d65e941ccf82586ceca043d65653f2e820
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-dhcp:
+        ref: 1aaf202978559f54bf9c8f1bc9453c06bb809cb1
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-dirtycow:
+        ref: 94f8545942d3a7d8c325437ef2866bdf6d251994
+        branch: master
+        tag: 1.0.4
+      pupmod-simp-fips:
+        ref: 4cedb9f2ab2dffc153f030569f3763449460f7eb
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-freeradius:
+        ref: b1c04e009efad2ff535963a239d96eb6232676f0
+        branch: master
+        tag: 7.0.1
+      pupmod-simp-gdm:
+        ref: f3b0b793b196e55c64bf6d5ce705e47ecf5811d9
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-gnome:
+        ref: c82fa085b973dcdda2641ffa62f06250f4c96be6
+        branch: master
+        tag: 8.0.0
+      puppet-haveged:
+        ref: 2f16d86710b1dddc47f51e409b094c9a54df8c7b
+        branch: master
+        tag: 0.4.5
+      pupmod-simp-incron:
+        ref: c8f82d2c762b4bf52492bd8f16bfa527274987b5
+        branch: master
+        tag: 0.3.1
+      pupmod-simp-iptables:
+        ref: ec0440a9e81fe286269ed3a9b5e2c28f819946e6
+        branch: master
+        tag: 6.1.6
+      pupmod-simp-issue:
+        ref: 2f011ff6a840b3633f585e9c6512f515ad307a60
+        branch: master
+        tag: 0.0.3
+      pupmod-simp-jenkins:
+        ref: add24f99fb3c5f7537489f0766b85f6273cf808e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-journald:
+        ref: 00114b643ff50bb1fe69166ec770e7b38ef78f71
+        branch: master
+        tag: 0.6.0
+      pupmod-simp-krb5:
+        ref: e2c7d66805cf8dbc5918f6381c6b6de87d6d6f2c
+        branch: master
+        tag: 7.0.3
+      pupmod-simp-libreswan:
+        ref: 60f21c5e0b8adf8a99e5f49773ee5d4e26220f90
+        branch: master
+        tag: 3.0.2
+      pupmod-simp-libvirt:
+        ref: 5195265ccf6203eeecd41d7b6a3a62ceca5197c2
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-logrotate:
+        ref: c2f9835bd39fe880696869a804a8a86ffb14e550
+        branch: master
+        tag: 6.3.0
+      pupmod-simp-mcafee:
+        ref: daff4cd505643edf69b4c0411d00bf543d9a8b42
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-mcollective:
+        ref: 185d58bd3400fb051f4b41e488dca7a2dde58b85
+        branch: master
+        tag: 2.3.3
+      pupmod-simp-mozilla:
+        ref: 8f0931ee82a65dd3cbb388584bebba10f235c338
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-named:
+        ref: 851fdeb82573b593ff935a9bd208b77395b5af87
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-network:
+        ref: 62c73747e2fe93f59aa588abba20faad70fdebf1
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-nfs:
+        ref: 88889f936f764a80d270f7e8c70458ee503bd51e
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-ntpd:
+        ref: 1d460b64c615470a8d267b47a83ecc1fbfe3550a
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-oddjob:
+        ref: 3eda3e21ccf4e467e0401b283386bf8db881f630
+        branch: master
+        tag: 2.1.0
+      pupmod-simp-simp_openldap:
+        ref: e4ad8ce3f6856eb943de27fa1f67453d9520d5b9
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-openscap:
+        ref: c51faa8ea78bea4aaa5834669ec4f3d5d0854a99
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-pam:
+        ref: 354c07c5b4173cf43e1b4a0d534474bbd247b200
+        branch: master
+        tag: 6.2.1
+      pupmod-simp-pki:
+        ref: 0346d20b813b6ad0fc9a0961eb0963aa536384cc
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-polkit:
+        ref: 7e9c50bdca341cb61f52aae1a49eb1ea65359fdc
+        branch: master
+        tag: 6.1.1
+      pupmod-simp-postfix:
+        ref: 75581cfd1437c95998797b6b5071fea03b81ecbc
+        branch: master
+        tag: 5.1.0
+      pupmod-simp-pupmod:
+        ref: 34652dddafb89edbae24eed18580c434cc5d46a5
+        branch: master
+        tag: 7.6.1
+      puppetlabs-puppetdb:
+        ref: 6cc68c030d9a41e9e3ab939f1d6c73ae999256a8
+        branch: master
+        tag: 7.1.0
+      pupmod-simp-resolv:
+        ref: 8dffcc02d51b80574596a54bb7496478effa05b0
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-rsyslog:
+        ref: 0c9cc87c9dbff3a22296355f6fedde0a9726efc4
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-selinux:
+        ref: b2bef5fb5646efdb85ce0a4c8143c588203ac851
+        branch: master
+        tag: 2.2.0
+      pupmod-simp-simp:
+        ref: fb622ca171e2df9a53f87afa3815a31ba9420e25
+        branch: master
+        tag: 4.5.0
+      pupmod-simp-simpcat:
+        ref: 3e39784e24e5ee96214ae227acfbbb3091cababb
+        branch: master
+        tag: 6.0.2
+      pupmod-simp-apache:
+        ref: 40533b06a1ff38dcd0c6569cbb0f2445d573164e
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-simp_elasticsearch:
+        ref: 9fb4dbe0bb9ac0dfe2b576e165668ffe588c7a00
+        branch: master
+        tag: 5.0.4
+      pupmod-simp-simp_grafana:
+        ref: d1c22d138a6775377d18746c2f02c02d4b2c0f6a
+        branch: master
+        tag: 1.0.3
+      pupmod-simp-simp_logstash:
+        ref: 2f455dd82663186d77f0a2b40c4554d4a747ae35
+        branch: master
+        tag: 5.0.2
+      pupmod-simp-simp_options:
+        ref: 48ff34d16499364da5b47c526949473c7e0682ce
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-simp_nfs:
+        ref: 984f8e745b24bae269e8a9d50099a296088c4f2f
+        branch: master
+        tag: 0.0.5
+      pupmod-simp-simp_rsyslog:
+        ref: a2ebef2054c5fb4d3e2624bf606dfbb9f83b604b
+        branch: master
+        tag: 0.2.0
+      pupmod-simp-simplib:
+        ref: bad2f755426586868ab0720ad11eb2a42c0c7447
+        branch: master
+        tag: 3.11.0
+      pupmod-simp-site:
+        ref: 8b401b7b1f45ab4e39e777bc07fb423dc9d530d0
+        branch: master
+        tag: 2.0.5
+      pupmod-simp-ssh:
+        ref: 79fd5c57b6e48409a8c482666e926efec29e31c4
+        branch: master
+        tag: 6.4.4
+      pupmod-simp-sssd:
+        ref: 8fb7d2685984708347fc3d707332acfa9186d398
+        branch: master
+        tag: 6.1.3
+      pupmod-simp-stunnel:
+        ref: b32720c639952b9d8f3a96e2724648d6609a672a
+        branch: master
+        tag: 6.3.2
+      pupmod-simp-sudo:
+        ref: 476fdabaf03b0befe1f580c065eed00c1b45d85b
+        branch: master
+        tag: 5.1.1
+      pupmod-simp-sudosh:
+        ref: 0df590e97b9081b66aeb5e33ea9e24455e9f0316
+        branch: master
+        tag: 6.0.1
+      pupmod-simp-svckill:
+        ref: d1b6c4a5991a7216e01fabc23d5f5b1c0e2c866a
+        branch: master
+        tag: 3.2.6
+      pupmod-simp-swap:
+        ref: d027e3607ac337918a2174e170a72ad57cd49da0
+        branch: master
+        tag: 0.1.1
+      pupmod-simp-tcpwrappers:
+        ref: 49c54b9253737b11fecbdbe972bf36ede55e700e
+        branch: master
+        tag: 6.1.0
+      pupmod-simp-tftpboot:
+        ref: a401004a373decd1e6bdc92fae6620ba6160585d
+        branch: master
+        tag: 6.2.0
+      pupmod-simp-tpm:
+        ref: f50654075b249f5a427dfe28bd7f665f9b36944a
+        branch: master
+        tag: 1.2.1
+      pupmod-simp-tuned:
+        ref: 5bc0a0e354675b205008abaa915f4fde07404a5b
+        branch: master
+        tag: 0.1.0
+      pupmod-simp-upstart:
+        ref: 7da363b00ffbb52096c958a987cb3064465b987f
+        branch: master
+        tag: 6.0.3
+      pupmod-simp-vnc:
+        ref: 19af919e8a6f622b5f7bebc7d2dec5091d56e01e
+        branch: master
+        tag: 7.0.0
+      pupmod-simp-vsftpd:
+        ref: 7fe4dd4983665361dae6503b8941e48e107041b7
+        branch: master
+        tag: 7.2.0
+      pupmod-simp-xinetd:
+        ref: 8044eaa24585d0db41a593a249b97c95a0a4068b
+        branch: master
+        tag: 4.1.0
+      pupmod-simp-useradd:
+        ref: 693fd682d7bac77f7697a6d8f483a2e752078a5e
+        branch: master
+        tag: 0.2.1
+      puppet-nsswitch:
+        ref: 506a7f0fcecc72000f87a42ebf564ccdfd895d37
+        branch: master
+        tag: 2.0.0
+      pupmod-simp-libkv:
+        tag: 0.6.1f
+        ref: de631cc5c485fd872c719955b780861e76fea6d5
+        branch: develop
+      pupmod-simp-simp_consul:
+        tag: 0.1.0
+        ref: 4f97881d17c5ce2e294c42a052386c39ad57921d
+        branch: develop
+      solarkennedy-consul:
+        ref: 3ed6c6495e7df079d69c55315eb64c277cfe6314
+        tag: v3.3.1
+      puppet-archive:
+        ref: 62f42713403dd9102bb1ac687924ea00dab50741
+      rubygem-simp-metadata:
+        ref: 38f5a9174eee1618c2358618d8a77ea45234b3fd
+        tag: 0.5.2
+      rubygem-simp-rake-helpers:
+        ref: d85b56bf7c8ee234aa822cb349865b3962c5d11b
+        tag: 5.6.3
+      pkg-r10k:
+        tag: 2.6.2-1
+        ref: 7c699efd368aa0c6d5e6002749dadc5696002235
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/tests/test-diff.yaml
+++ b/v1/tests/test-diff.yaml
@@ -1,11 +1,16 @@
 ---
 releases:
   test-diff:
-    pupmod-simp-activemq:
-      buildinfo:
-        rpm:
-          build_method: metadata-build
-      ref: 3987ra0d5b53063f493b93a596626193b71dddd4
-      branch: develop
-      version: 1.1.2
-      tag: 1.1.2
+    components:
+      pupmod-simp-activemq:
+        buildinfo:
+          rpm:
+            build_method: metadata-build
+        ref: 3987ra0d5b53063f493b93a596626193b71dddd4
+        branch: develop
+        version: 1.1.2
+        tag: 1.1.2
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:

--- a/v1/tests/test-stub.yaml
+++ b/v1/tests/test-stub.yaml
@@ -1,8 +1,13 @@
 ---
 releases:
   test-stub:
-    pupmod-simp-activemq:
-      ref: 488f5a0d5b53063c125b93a596626193b71aaa08
-      branch: master
-      version: 1.1.1
-      tag: 1.1.1
+    components:
+      pupmod-simp-activemq:
+        ref: 488f5a0d5b53063c125b93a596626193b71aaa08
+        branch: master
+        version: 1.1.1
+        tag: 1.1.1
+    platforms:
+      CentOS-7.5-x86_64:
+      CentOS-6.10-x86_64:
+      RedHat-7.5-x86_64:


### PR DESCRIPTION
@heliocentric This is the format I've been using (can be changed if needed), but this allows us to search for components and packages separately, as well as have platform/iso data available for all releases. Please review at your earliest convenience. 